### PR TITLE
Import missing headers in kokoro on Linux

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -1,6 +1,7 @@
 #ifndef common_h
 #define common_h
 
+#include <string>
 #include <map>
 #include <vector>
 

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -1,6 +1,7 @@
 #ifndef tts_model_h
 #define tts_model_h
 
+#include <functional>
 #include "util.h"
 #include "common.h"
 

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,7 @@
 #ifndef util_h
 #define util_h
 
+#include <functional>
 #include <math.h>
 #include <random>
 #include <stdio.h>


### PR DESCRIPTION
Fixes breakage by a9dfd6a4db93beabc31d9f3b5e95a02a6524609e. I will need `<string>` properly set in `common.h` for a future commit. Submodule ggml needs separate `<complex.h>` fix