### PR TITLE
Improve performance on Windows/Linux by not recreating tens of thousands of threads

### DIFF
--- a/src/dac_model.h
+++ b/src/dac_model.h
@@ -89,16 +89,6 @@ void assign_to_audio_encoder(dac_model * model, std::string name, ggml_tensor * 
 // the context used for running the dac model
 struct dac_context : runner_context {
     dac_context(dac_model * model, int n_threads): runner_context(n_threads), model(model) {};
-    ~dac_context() {
-        ggml_backend_sched_free(sched);
-        ggml_backend_free(backend_cpu);
-        if (backend) {
-            ggml_backend_free(backend);
-        }
-        if (buf_output) {
-            ggml_backend_buffer_free(buf_output);
-        }
-    }
     
     struct dac_model * model;
     

--- a/src/kokoro_model.h
+++ b/src/kokoro_model.h
@@ -299,17 +299,7 @@ struct kokoro_ubatch {
 struct kokoro_duration_context : runner_context {
     kokoro_duration_context(kokoro_model * model, int n_threads): runner_context(n_threads), model(model) {};
     ~kokoro_duration_context() {
-        ggml_backend_sched_free(sched);
-        ggml_backend_free(backend_cpu);
-        if (backend) {
-            ggml_backend_free(backend);
-        }
-        if (buf_output) {
-            ggml_backend_buffer_free(buf_output);
-        }
-        if (buf_len_output) {
-        	ggml_backend_buffer_free(buf_len_output);
-        }
+        ggml_backend_buffer_free(buf_len_output);
     }
     
     std::string voice = "af_alloy";

--- a/src/parler_model.h
+++ b/src/parler_model.h
@@ -102,16 +102,6 @@ void assign_to_decoder(parler_tts_model * model, const std::string name, ggml_te
 
 struct parler_context : runner_context {
     parler_context(parler_tts_model * model, int n_threads): runner_context(n_threads), model(model) {};
-    ~parler_context() {
-        ggml_backend_sched_free(sched);
-        ggml_backend_free(backend_cpu);
-        if (backend) {
-            ggml_backend_free(backend);
-        }
-        if (buf_output) {
-            ggml_backend_buffer_free(buf_output);
-        }
-    }
     struct parler_tts_model * model;
     std::vector<bool> eos_seen;
 

--- a/src/parler_model.h
+++ b/src/parler_model.h
@@ -88,7 +88,7 @@ struct parler_tts_model : tts_model {
     void assign_weight(std::string name, ggml_tensor * tensor);
     void prep_constants(gguf_context * meta);
     void prep_layers(gguf_context * meta);
-    void prep_cross_key_values(struct tts_response * conditional_prompt = nullptr);
+    void prep_cross_key_values(int n_threads, struct tts_response * conditional_prompt = nullptr);
     void setup_from_file(gguf_context * meta_ctx, ggml_context * load_context, bool cpu_only) {
         prep_constants(meta_ctx);
         prep_layers(meta_ctx);

--- a/src/t5_encoder_model.h
+++ b/src/t5_encoder_model.h
@@ -75,16 +75,6 @@ void assign_to_t5_layer(t5_encoder * model, t5_layer & layer, std::string name, 
 
 struct t5_context : runner_context {
     t5_context(t5_encoder * model, int n_threads): runner_context(n_threads), model(model) {};
-    ~t5_context() {
-        ggml_backend_sched_free(sched);
-        ggml_backend_free(backend_cpu);
-        if (backend) {
-            ggml_backend_free(backend);
-        }
-        if (buf_output) {
-            ggml_backend_buffer_free(buf_output);
-        }
-    }
     
     struct t5_encoder * model;
     

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -22,7 +22,7 @@ struct tts_runner * parler_tts_from_file(gguf_context * meta_ctx, ggml_context *
     }
 
     if (config->use_cross_attn) {
-        runner->model->prep_cross_key_values();
+        runner->model->prep_cross_key_values(n_threads);
     }
 
     runner->prepare_post_load();

--- a/src/tts_model.cpp
+++ b/src/tts_model.cpp
@@ -11,6 +11,8 @@ void runner_context::set_threads() {
     }
     if (backend_cpu != nullptr) {
         ggml_backend_cpu_set_n_threads(backend_cpu, n_threads);
+        struct ggml_threadpool_params ttp = ggml_threadpool_params_default(n_threads);
+        threadpool = ggml_threadpool_new(&ttp);
         ggml_backend_cpu_set_threadpool(backend_cpu, threadpool);
     }
 }

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -9,6 +9,12 @@ using tensor_meta_callback = std::function<void(ggml_tensor*)>*;
 
 struct runner_context {
 	runner_context(int n_threads): n_threads(n_threads) {};
+    virtual ~runner_context() {
+        ggml_backend_sched_free(sched);
+        ggml_backend_free(backend_cpu);
+        ggml_backend_free(backend);
+        ggml_backend_buffer_free(buf_output);
+    }
     // TODO: extend the backend and buffer support out to all devices
     ggml_backend_t backend = nullptr;
     ggml_backend_buffer_type_t backend_buffer = nullptr;

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -11,6 +11,7 @@ struct runner_context {
 	runner_context(int n_threads): n_threads(n_threads) {};
     virtual ~runner_context() {
         ggml_backend_sched_free(sched);
+        ggml_threadpool_free(threadpool);
         ggml_backend_free(backend_cpu);
         ggml_backend_free(backend);
         ggml_backend_buffer_free(buf_output);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -81,25 +81,6 @@ struct ggml_tensor * snake_1d(ggml_context * ctx, struct ggml_tensor * alpha, st
     return ggml_add(ctx, a, ggml_mul(ctx, ggml_sqr(ctx, ggml_sin(ctx, ggml_mul(ctx, a, alpha))), ggml_reciprocal(ctx, alpha)));
 }
 
-uint64_t get_cpu_count() {
-    uint64_t cpu_count = 0;
-    size_t size = sizeof(cpu_count);
-#ifdef __APPLE__
-    if (sysctlbyname("hw.ncpu", &cpu_count, &size, NULL, 0) < 0) {
-        // this functionis only currently used to prepare static cross attention keys and values, and it is fast enough with a single cpu.
-        return 1;
-    }
-#elif __linux__
-    cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
-    if (cpu_count == -1) {
-        return 1;
-    }
-#else
-    // windows stuff
-#endif
-    return cpu_count;
-}
-
 bool has_suffix(std::string value, std::string suffix) {
     return value.size() >= suffix.size() && value.compare(value.size()-suffix.size(), suffix.size(), suffix) == 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -30,7 +30,6 @@ std::pair<int, std::string> parse_layer_count(std::string name, int skip = 0);
 
 struct model_tensor_meta compute_tensor_meta(std::string name_prefix, ggml_context * weight_ctx, std::function<void(ggml_tensor*)>* callback = nullptr);
 struct ggml_tensor * snake_1d(ggml_context * ctx, struct ggml_tensor * alpha, struct ggml_tensor * a);
-uint64_t get_cpu_count();
 int search_for_gguf_keys(gguf_context * meta, std::vector<std::string> possible_keys);
 
 // a simple window function for stft


### PR DESCRIPTION
This stops the uselessly spawn and destroy threads every `ggml_graph_compute` invocation. I saw a run with 10000+ threads created. Testing time has gone down from minutes to 10 seconds for me.

This is implemented only in `parler_model` for now. I also fixed `n_threads` wrongly defaulting to 1.