### PR TITLE
Adds VAD and fixes generative bugs

### DIFF
--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(cli
     playback.h
     write_file.cpp
     write_file.h
+    vad.cpp
+    vad.h
 )
 
 find_package(SDL2 REQUIRED CONFIG REQUIRED COMPONENTS SDL2)

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -14,23 +14,27 @@ In order to get a detailed breakdown the functionality currently available you c
 ./cli --help
 
 --temperature (-t):
-    The temperature to use when generating outputs. Defaults to 0.9.
+    The temperature to use when generating outputs. Defaults to 1.0.
 --repetition-penalty (-r):
-    The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.1.
+    The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.
 --n-threads (-nt):
-    The number of cpu threads to run generation with. Defaults to 10.
+    The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined then it defaults to 1.
 --topk (-tk):
-    (OPTIONAL) when set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.
+    (OPTIONAL) When set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.
 --use-metal (-m):
     (OPTIONAL) Whether to use metal acceleration
 --no-cross-attn (-ca):
     (OPTIONAL) Whether to not include cross attention
+--vad (-va):
+    (OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TSS). By default, no VAD is applied.
+--play:
+    (OPTIONAL) Whether to play back the audio immediately instead of saving it to file.
 --model-path (-mp):
     (REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.
 --prompt (-p):
     (REQUIRED) The text prompt for which to generate audio in quotation markers.
 --save-path (-sp):
-    (REQUIRED) The path to save the audio output to in a .wav format.
+    (OPTIONAL) The path to save the audio output to in a .wav format. Defaults to TTS.cpp.wav
 --conditional-prompt (-cp):
     (OPTIONAL) A distinct conditional prompt to use for generating. If none is provided the preencoded prompt is used. '--text-encoder-path' must be set to use conditional generation.
 --text-encoder-path (-tep):

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -15,16 +15,16 @@ int main(int argc, const char ** argv) {
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.", "-mp", true));
     args.add_argument(string_arg("--prompt", "(REQUIRED) The text prompt for which to generate audio in quotation markers.", "-p", true));
     args.add_argument(string_arg("--save-path", "(OPTIONAL) The path to save the audio output to in a .wav format. Defaults to TTS.cpp.wav", "-sp", false, "TTS.cpp.wav"));
-    args.add_argument(float_arg("--temperature", "The temperature to use when generating outputs. Defaults to 0.9.", "-t", false, &default_temperature));
+    args.add_argument(float_arg("--temperature", "The temperature to use when generating outputs. Defaults to 1.0.", "-t", false, &default_temperature));
     args.add_argument(int_arg("--n-threads", "The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined then it defaults to 1.", "-nt", false, &default_n_threads));
     args.add_argument(int_arg("--topk", "(OPTIONAL) When set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.", "-tk", false, &default_top_k));
-    args.add_argument(float_arg("--repetition-penalty", "The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.1.", "-r", false, &default_repetition_penalty));
+    args.add_argument(float_arg("--repetition-penalty", "The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.", "-r", false, &default_repetition_penalty));
     args.add_argument(bool_arg("--use-metal", "(OPTIONAL) Whether to use metal acceleration", "-m"));
     args.add_argument(bool_arg("--no-cross-attn", "(OPTIONAL) Whether to not include cross attention", "-ca"));
     args.add_argument(string_arg("--conditional-prompt", "(OPTIONAL) A distinct conditional prompt to use for generating. If none is provided the preencoded prompt is used. '--text-encoder-path' must be set to use conditional generation.", "-cp", false));
     args.add_argument(string_arg("--text-encoder-path", "(OPTIONAL) The local path of the text encoder gguf model for conditional generaiton.", "-tep", false));
     args.add_argument(string_arg("--voice", "(OPTIONAL) The voice to use to generate the audio. This is only used for models with voice packs.", "-v", false, "af_alloy"));
-    args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice activity detection (VAD) and strip silence form the output. By default, no VAD is applied.", "-va"));
+    args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TSS). By default, no VAD is applied.", "-va"));
     register_play_tts_response_args(args);
     args.parse(argc, argv);
     if (args.for_help) {
@@ -50,7 +50,6 @@ int main(int argc, const char ** argv) {
     tts_response data;
 
     generate(runner, args.get_string_param("--prompt"), &data, config);
-    write_audio_file(data, "/Users/matthewwillett-jeffries/Desktop/test2.wav", runner->sampling_rate);
     if (args.get_bool_param("--vad")) {
         apply_energy_voice_inactivity_detection(data, runner->sampling_rate);
     }

--- a/examples/cli/vad.cpp
+++ b/examples/cli/vad.cpp
@@ -1,0 +1,53 @@
+#include "vad.h"
+
+float energy(float * chunk, int count) {
+	float en = 0.0f;
+	for (int i = 0; i < count; i++) {
+		en += powf(chunk[i], 2.0f);
+	}
+	return en;
+}
+
+void apply_energy_voice_inactivity_detection(
+	tts_response & data, 
+	float sample_rate, 
+	int ms_per_frame,
+	int frame_threshold,
+	float normalized_energy_threshold) {
+	int samples_per_frame = (int) (ms_per_frame * sample_rate / 1000.0f);
+	int n_frames = (int) (data.n_outputs / samples_per_frame);
+
+	// for min-max normalization
+	float max_energy = 0.0f;
+	float min_energy = 0.0f;
+	float * energies = (float *) malloc(n_frames * sizeof(float));
+
+	// compute the energies and the necessary elements for min-max normalization
+	for (int i = 0; i < n_frames; i++) {
+		float * chunk = data.data + i * samples_per_frame;
+		energies[i] = energy(chunk, samples_per_frame);
+		if (i == 0) {
+			max_energy = energies[i];
+			min_energy = energies[i];
+		} else if (energies[i] > max_energy) {
+			max_energy = energies[i];
+		} else if (energies[i] < min_energy) {
+			min_energy = energies[i];
+		}
+	}
+
+	int concurrent_silent_frames = 0;
+
+	for (int i = 0; i < n_frames; i++) {
+		float frame_energy = (energies[i] - min_energy) / (max_energy - min_energy);
+		if (frame_energy < normalized_energy_threshold) {
+			concurrent_silent_frames++;
+		} else {
+			concurrent_silent_frames = 0;
+		}
+	}
+	if (concurrent_silent_frames >= frame_threshold) {
+		data.n_outputs -= ((concurrent_silent_frames - 1) * samples_per_frame);
+	}
+	free(energies);
+}

--- a/examples/cli/vad.cpp
+++ b/examples/cli/vad.cpp
@@ -14,14 +14,18 @@ void apply_energy_voice_inactivity_detection(
 	int ms_per_frame,
 	int frame_threshold,
 	float normalized_energy_threshold,
-	int trailing_silent_frames) {
+	int trailing_silent_frames,
+	int early_cutoff_seconds_threshold,
+	float early_cutoff_energy_threshold) {
 	int samples_per_frame = (int) (ms_per_frame * sample_rate / 1000.0f);
 	int n_frames = (int) (data.n_outputs / samples_per_frame);
+	int early_cuttoff_frames = (int)((early_cutoff_seconds_threshold * 1000) / ms_per_frame);
 
 	// for min-max normalization
 	float max_energy = 0.0f;
 	float min_energy = 0.0f;
 	float * energies = (float *) malloc(n_frames * sizeof(float));
+	int silent_frames = 0;
 
 	// compute the energies and the necessary elements for min-max normalization
 	for (int i = 0; i < n_frames; i++) {
@@ -35,16 +39,26 @@ void apply_energy_voice_inactivity_detection(
 		} else if (energies[i] < min_energy) {
 			min_energy = energies[i];
 		}
+		if (energies[i] <= early_cutoff_energy_threshold) {
+			silent_frames++;
+		} else {
+			silent_frames = 0;
+		}
+		if (silent_frames >= early_cuttoff_frames) {
+			data.n_outputs = (i + trailing_silent_frames - silent_frames) * samples_per_frame;
+			free(energies);
+			return;
+		}
 	}
 
 	int concurrent_silent_frames = 0;
 
-	for (int i = 0; i < n_frames; i++) {
-		float frame_energy = (energies[i] - min_energy) / (max_energy - min_energy);
+	for (int i = n_frames; i > 0; i--) {
+		float frame_energy = (energies[i-1] - min_energy) / (max_energy - min_energy);
 		if (frame_energy < normalized_energy_threshold) {
 			concurrent_silent_frames++;
 		} else {
-			concurrent_silent_frames = 0;
+			break;
 		}
 	}
 	if (concurrent_silent_frames >= frame_threshold) {

--- a/examples/cli/vad.cpp
+++ b/examples/cli/vad.cpp
@@ -13,7 +13,8 @@ void apply_energy_voice_inactivity_detection(
 	float sample_rate, 
 	int ms_per_frame,
 	int frame_threshold,
-	float normalized_energy_threshold) {
+	float normalized_energy_threshold,
+	int trailing_silent_frames) {
 	int samples_per_frame = (int) (ms_per_frame * sample_rate / 1000.0f);
 	int n_frames = (int) (data.n_outputs / samples_per_frame);
 
@@ -47,7 +48,7 @@ void apply_energy_voice_inactivity_detection(
 		}
 	}
 	if (concurrent_silent_frames >= frame_threshold) {
-		data.n_outputs -= ((concurrent_silent_frames - 1) * samples_per_frame);
+		data.n_outputs -= ((concurrent_silent_frames - trailing_silent_frames) * samples_per_frame);
 	}
 	free(energies);
 }

--- a/examples/cli/vad.h
+++ b/examples/cli/vad.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <math.h>
+#include "common.h"
+
+float energy(float * chunk, int count);
+
+void apply_energy_voice_inactivity_detection(
+	tts_response & data, 
+	float sample_rate = 44100.0f, 
+	int ms_per_frame = 10,
+	int frame_threshold = 20,
+	float normalized_energy_threshold = 0.01f);

--- a/examples/cli/vad.h
+++ b/examples/cli/vad.h
@@ -5,9 +5,14 @@
 
 float energy(float * chunk, int count);
 
+/*
+ * This function is used to trim trailing silence at the end of audio data within the tts_response struct.
+ * It detects silence by min-max normalizing energy and trimming frames which fall under a relative threshold.
+ */
 void apply_energy_voice_inactivity_detection(
 	tts_response & data, 
-	float sample_rate = 44100.0f, 
-	int ms_per_frame = 10,
-	int frame_threshold = 20,
-	float normalized_energy_threshold = 0.01f);
+	float sample_rate = 44100.0f, // the sample rate of the audio
+	int ms_per_frame = 10, // the audio time per frame
+	int frame_threshold = 20, // the number of trailing empty frames upon which silence is clipped.
+	float normalized_energy_threshold = 0.01f, // the normalized threshold to determine a silent frame
+	int trailing_silent_frames = 5);

--- a/examples/cli/vad.h
+++ b/examples/cli/vad.h
@@ -15,4 +15,7 @@ void apply_energy_voice_inactivity_detection(
 	int ms_per_frame = 10, // the audio time per frame
 	int frame_threshold = 20, // the number of trailing empty frames upon which silence is clipped.
 	float normalized_energy_threshold = 0.01f, // the normalized threshold to determine a silent frame
-	int trailing_silent_frames = 5);
+	int trailing_silent_frames = 5, // the number of frames of silence to allow
+	int early_cutoff_seconds_threshold = 3, // the number of seconds of complete silence before terminating and cutting audio early
+	float early_cutoff_energy_threshold = 0.1 // the energy threshold for treating a frame as silent for early cutoff
+);

--- a/examples/perf_battery/perf_battery.cpp
+++ b/examples/perf_battery/perf_battery.cpp
@@ -82,10 +82,10 @@ std::string benchmark_printout(tts_arch arch, std::vector<double> generation_sam
 
 
 int main(int argc, const char ** argv) {
-    float default_temperature = 0.9f;
+    float default_temperature = 1.0f;
     int default_n_threads = std::max((int)std::thread::hardware_concurrency(), 1);
     int default_top_k = 50;
-    float default_repetition_penalty = 1.1f;
+    float default_repetition_penalty = 1.0f;
 	arg_list args;
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini v1.", "-mp", true));
     args.add_argument(int_arg("--n-threads", "The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined it defaults to 1.", "-nt", false, &default_n_threads));

--- a/examples/perf_battery/perf_battery.cpp
+++ b/examples/perf_battery/perf_battery.cpp
@@ -89,9 +89,9 @@ int main(int argc, const char ** argv) {
 	arg_list args;
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini v1.", "-mp", true));
     args.add_argument(int_arg("--n-threads", "The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined it defaults to 1.", "-nt", false, &default_n_threads));
-    args.add_argument(float_arg("--temperature", "The temperature to use when generating outputs. Defaults to 0.9.", "-t", false, &default_temperature));
+    args.add_argument(float_arg("--temperature", "The temperature to use when generating outputs. Defaults to 1.0.", "-t", false, &default_temperature));
     args.add_argument(int_arg("--topk", "(OPTIONAL) When set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.", "-tk", false, &default_top_k));
-    args.add_argument(float_arg("--repetition-penalty", "The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.1.", "-r", false, &default_repetition_penalty));
+    args.add_argument(float_arg("--repetition-penalty", "The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.", "-r", false, &default_repetition_penalty));
     args.add_argument(bool_arg("--use-metal", "(OPTIONAL) whether or not to use metal acceleration.", "-m"));
     args.add_argument(bool_arg("--no-cross-attn", "(OPTIONAL) Whether to not include cross attention", "-ca"));
     args.parse(argc, argv);

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -10,7 +10,7 @@ In order to get a detailed breakdown of the functionality currently available yo
 ./build/bin/tts-server --help
 
 --temperature (-t):
-    (OPTIONAL) The temperature to use when generating outputs by default. Defaults to 0.9.
+    (OPTIONAL) The temperature to use when generating outputs by default. Defaults to 1.0.
 --repetition-penalty (-r):
     The by channel repetition penalty to be applied to the sampled output of the model by default. defaults to 1.0.
 --topk (-tk):

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -357,9 +357,9 @@ int main(int argc, const char ** argv) {
     int default_port = 8080;
     int default_timeout = 300;
     std::string default_host = "127.0.0.1";
-    float default_temperature = 0.9f;
+    float default_temperature = 1.0f;
     int default_top_k = 50;
-    float default_repetition_penalty = 1.1f;
+    float default_repetition_penalty = 1.0f;
 
     arg_list args;
     args.add_argument(float_arg("--temperature", "(OPTIONAL) The temperature to use when generating outputs. Defaults to 0.9.", "-t", false, &default_temperature));

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -362,7 +362,7 @@ int main(int argc, const char ** argv) {
     float default_repetition_penalty = 1.0f;
 
     arg_list args;
-    args.add_argument(float_arg("--temperature", "(OPTIONAL) The temperature to use when generating outputs. Defaults to 0.9.", "-t", false, &default_temperature));
+    args.add_argument(float_arg("--temperature", "(OPTIONAL) The temperature to use when generating outputs. Defaults to 1.0.", "-t", false, &default_temperature));
     args.add_argument(int_arg("--topk", "(OPTIONAL) when set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.", "-tk", false, &default_top_k));
     args.add_argument(float_arg("--repetition-penalty", "The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.", "-r", false, &default_repetition_penalty));
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1 or Kokoro.", "-mp", true));

--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -211,9 +211,11 @@ static struct ggml_tensor * dac_build_audio_inputs(struct ggml_context * ctx, st
     
     dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length*dctx->model->n_heads);
     ggml_set_input(dctx->inp_tokens);
+
+    /*
     if (dctx->backend) {
         ggml_backend_sched_set_tensor_backend(dctx->sched, dctx->inp_tokens, dctx->backend);
-    }
+    }*/
 
     for(int i = 0; i < dctx->model->n_heads; i++) {
         auto quantize_layer = dctx->model->quantizer_layers[i];

--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -212,10 +212,9 @@ static struct ggml_tensor * dac_build_audio_inputs(struct ggml_context * ctx, st
     dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length*dctx->model->n_heads);
     ggml_set_input(dctx->inp_tokens);
 
-    /*
     if (dctx->backend) {
         ggml_backend_sched_set_tensor_backend(dctx->sched, dctx->inp_tokens, dctx->backend);
-    }*/
+    }
 
     for(int i = 0; i < dctx->model->n_heads; i++) {
         auto quantize_layer = dctx->model->quantizer_layers[i];

--- a/src/parler_model.h
+++ b/src/parler_model.h
@@ -59,6 +59,7 @@ struct parler_tts_model : tts_model {
     // These default configurations are based on the configuration of Parler TTS Mini (version 1.0)
     uint32_t n_output_heads = 9;
     uint32_t n_encode_length;
+    uint32_t max_encode_length = 512; // This corresponds with the max token length of the conditional prompt
     uint32_t hidden_size = 1024;
     uint32_t max_ctx_length = 4096;
     uint32_t n_attn_heads = 16;
@@ -92,7 +93,7 @@ struct parler_tts_model : tts_model {
     void setup_from_file(gguf_context * meta_ctx, ggml_context * load_context, bool cpu_only) {
         prep_constants(meta_ctx);
         prep_layers(meta_ctx);
-        tts_model::setup_from_file(meta_ctx, load_context, cpu_only, "decoder", 1.25, n_encode_length*hidden_size*sizeof(float)*n_layers*2);
+        tts_model::setup_from_file(meta_ctx, load_context, cpu_only, "decoder", 1.30, max_encode_length*hidden_size*sizeof(float)*n_layers*2);
     }
 };
 


### PR DESCRIPTION
- Adds Energy derived voice activity detection (VAD) for trimming silence from Parler TTS generation.
- Aligns default generation configuration with Parler TTS Torch implementation
- Fixes a buffer overflow bug present when changing the conditional prompt for Parler TTS.
- Makes permuted `a` tensor contiguous to avoid race condition in mul_mat.
- Actually disable cross attention when `--no-cross-attn` is passed to the cli.