### PR TITLE
Fix espeak-ng-data on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(ESPEAK espeak-ng)
     if (ESPEAK_FOUND)
-        set(ESPEAK_CFLAGS_OTHER "${ESPEAK_CFLAGS_OTHER} -DESPEAK_INSTALL=1 -DESPEAK_DATA_PATH=\\\"${ESPEAK_PREFIX}/share\\\"")
+        set(ESPEAK_CFLAGS_OTHER "${ESPEAK_CFLAGS_OTHER} -DESPEAK_INSTALL=1 -DESPEAK_DATA_PATH=\\\"${ESPEAK_LIBDIR}/espeak-ng-data\\\"")
     endif()
 endif()
 

--- a/examples/phonemize/phonemize.cpp
+++ b/examples/phonemize/phonemize.cpp
@@ -7,7 +7,7 @@ int main(int argc, const char ** argv) {
     args.add_argument(string_arg("--phonemizer-path", "(OPTIONAL) The local path of the gguf phonemiser file for TTS.cpp phonemizer. This is required if not using espeak.", "-mp"));
     args.add_argument(string_arg("--prompt", "(REQUIRED) The text prompt to phonemize.", "-p", true));
     args.add_argument(bool_arg("--use-espeak", "(OPTIONAL) Whether to use espeak to generate phonems.", "-ue"));
-    args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The voice id to use for espeak phonemization. Defaults to 'gmw/en-US'.", "-eid", false, "gmw/en-US"))
+    args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The voice id to use for espeak phonemization. Defaults to 'gmw/en-US'.", "-eid", false, "gmw/en-US"));
     args.parse(argc, argv);
     if (args.for_help) {
         args.help();

--- a/include/common.h
+++ b/include/common.h
@@ -1,6 +1,7 @@
 #ifndef common_h
 #define common_h
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <vector>


### PR DESCRIPTION
This fixes my wrong path from #10 and 3 recent complication errors.

# Before

```console
$ make -j24
[...]
In file included from /home/home/CLionProjects/TTS-cpp/TTS.cpp/examples/cli/vad.cpp:1:
In file included from /home/home/CLionProjects/TTS-cpp/TTS.cpp/examples/cli/vad.h:4:
/home/home/CLionProjects/TTS-cpp/TTS.cpp/src/../include/common.h:13:2: error: unknown type name 'uint32_t'
   13 |         uint32_t hidden_size; // this parameter is only currently used by the t5_encoder for which n_outputs corresponds to sequence length;
      |         ^
/home/home/CLionProjects/TTS-cpp/TTS.cpp/src/../include/common.h:50:30: error: use of undeclared identifier 'uint8_t'
   50 |         void init_build(std::vector<uint8_t>* buf_compute_meta);
      |                                     ^
2 errors generated.
make[2]: *** [examples/cli/CMakeFiles/cli.dir/build.make:118: examples/cli/CMakeFiles/cli.dir/vad.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/home/home/CLionProjects/TTS-cpp/TTS.cpp/examples/phonemize/phonemize.cpp:10:168: error: expected ';' after expression
   10 |     args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The voice id to use for espeak phonemization. Defaults to 'gmw/en-US'.", "-eid", false, "gmw/en-US"))
      |                                                                                                                                                                        ^
      |                                                                                                                                                                        ;
1 error generated.
make[2]: *** [examples/phonemize/CMakeFiles/phonemize.dir/build.make:76: examples/phonemize/CMakeFiles/phonemize.dir/phonemize.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:532: examples/phonemize/CMakeFiles/phonemize.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 97%] Linking CXX executable ../../bin/quantize
[ 97%] Linking CXX executable ../../bin/perf_battery
make[1]: *** [CMakeFiles/Makefile2:412: examples/cli/CMakeFiles/cli.dir/all] Error 2
[ 97%] Built target perf_battery
[ 97%] Built target quantize
[ 98%] Linking CXX executable ../../bin/tts-server
[ 98%] Built target tts-server
make: *** [Makefile:136: all] Error 2
$ # After the first commit:
$ bin/cli -mp ~/Kokoro_espeak.gguf -p "$(<prompt.txt)"
Error processing file '/usr/share/phontab': No such file or directory.
```

# After

Kokoro works