### PR TITLE
simplifies output retrieval code and adds protection for buffer over-read

### DIFF
--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -335,9 +335,7 @@ void dac_runner::run(uint32_t * input_tokens, uint32_t sequence_length, struct t
 
     ggml_backend_sched_graph_compute_async(dctx->sched, gf);
 
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(dctx->sched, result);
-
-    ggml_backend_tensor_get_async(backend_res, result, outputs->data, 0, batch.sequence_length*sizeof(float)*model->up_sampling_factor);
+    dctx->get_ggml_node_data(result, outputs->data, batch.sequence_length*sizeof(float)*model->up_sampling_factor);
 
     // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
     // overlap with device computation.

--- a/src/kokoro_model.cpp
+++ b/src/kokoro_model.cpp
@@ -1095,11 +1095,8 @@ void kokoro_duration_runner::run(kokoro_ubatch & batch) {
 
     ggml_backend_sched_graph_compute_async(kctx->sched, gf);
 
-    ggml_backend_t backend_lens_res = ggml_backend_sched_get_tensor_backend(kctx->sched, lens);
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(kctx->sched, hidden_states);
-
-    ggml_backend_tensor_get_async(backend_lens_res, lens, batch.resp->lengths, 0, batch.n_tokens*sizeof(float));
-    ggml_backend_tensor_get_async(backend_res, hidden_states, batch.resp->hidden_states, 0, batch.n_tokens*(model->duration_hidden_size+model->style_half_size)*sizeof(float));
+    kctx->get_ggml_node_data(lens, batch.resp->lengths, batch.n_tokens*sizeof(float), kctx->buf_len_output);
+    kctx->get_ggml_node_data(hidden_states, batch.resp->hidden_states, batch.n_tokens*(model->duration_hidden_size+model->style_half_size)*sizeof(float));
 
     // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
     // overlap with device computation.
@@ -1285,9 +1282,7 @@ void kokoro_runner::run(kokoro_ubatch & batch, tts_response * outputs) {
 
     ggml_backend_sched_graph_compute_async(kctx->sched, gf);
 
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(kctx->sched, output);
-
-    ggml_backend_tensor_get_async(backend_res, output, outputs->data, 0, new_size);
+    kctx->get_ggml_node_data(output, outputs->data, new_size);
 
     // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
     // overlap with device computation.

--- a/src/parler_model.cpp
+++ b/src/parler_model.cpp
@@ -693,10 +693,9 @@ int parler_tts_runner::decode(parler_ubatch & batch) {
 
     set_inputs(batch);
     parler_graph_compute(gf);
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(pctx->sched, res);
 
     float * logits_out = pctx->logits + pctx->n_outputs * model->output_vocab_size * model->n_output_heads;
-    ggml_backend_tensor_get_async(backend_res, res, logits_out, 0, n_outputs_new*model->output_vocab_size*model->n_output_heads*sizeof(float));
+    pctx->get_ggml_node_data(res, logits_out, n_outputs_new*model->output_vocab_size*model->n_output_heads*sizeof(float));
 
     // set to total number of outputs in the batch*/
     pctx->n_outputs += n_outputs_new;

--- a/src/t5_encoder_model.cpp
+++ b/src/t5_encoder_model.cpp
@@ -349,9 +349,7 @@ void t5_runner::run(uint32_t * input_tokens, uint32_t sequence_length, struct tt
 
     ggml_backend_sched_graph_compute_async(t5ctx->sched, gf);
 
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(t5ctx->sched, result);
-
-    ggml_backend_tensor_get_async(backend_res, result, outputs->data, 0, batch.n_tokens*sizeof(float)*model->output_size);
+    t5ctx->get_ggml_node_data(result, outputs->data, batch.n_tokens*sizeof(float)*model->output_size);
 
     // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
     // overlap with device computation.

--- a/src/tts_model.cpp
+++ b/src/tts_model.cpp
@@ -19,7 +19,7 @@ void append_to_response(struct tts_response * response, struct tts_response * to
  * Pulls output_size to prepped buffer 'output' from 'output_node' tensor. If no buffer is passed will default to the existing output buffer present 
  * on runner_context. 
  */
-void runner_context::get_ggml_node_data(struct ggml_tensor * output_node, float * output, const size_t output_size, ggml_backend_buffer_t buffer) {
+void runner_context::get_ggml_node_data(struct ggml_tensor * output_node, float * output, size_t output_size, ggml_backend_buffer_t buffer) {
     if (buffer == nullptr) {
         buffer = buf_output;
     }

--- a/src/tts_model.cpp
+++ b/src/tts_model.cpp
@@ -15,6 +15,23 @@ void append_to_response(struct tts_response * response, struct tts_response * to
     response->n_outputs += to_append->n_outputs;
 }
 
+/* 
+ * Pulls output_size to prepped buffer 'output' from 'output_node' tensor. If no buffer is passed will default to the existing output buffer present 
+ * on runner_context. 
+ */
+void runner_context::get_ggml_node_data(struct ggml_tensor * output_node, float * output, const size_t output_size, ggml_backend_buffer_t buffer) {
+    if (buffer == nullptr) {
+        buffer = buf_output;
+    }
+    if (ggml_backend_buffer_get_size(buffer) < output_size) {
+        TTS_ABORT("Output buffer overflow of %d / %d for output node '%s'\n", output_size, ggml_backend_buffer_get_size(buffer), ggml_get_name(output_node));
+    } else if (ggml_nbytes(output_node) < output_size) {
+        TTS_ABORT("Output node, '%s', with %d bytes is too small for #ggml_backend_tensor_get_async with size of %d.\n", ggml_get_name(output_node), ggml_nbytes(output_node), output_size);
+    }
+    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched, output_node);
+    ggml_backend_tensor_get_async(backend_res, output_node, output, 0, output_size);
+}
+
 void runner_context::set_threads() {
     if (backend != nullptr) {
 #ifdef GGML_USE_METAL

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -32,7 +32,7 @@ struct runner_context {
     ggml_threadpool_t threadpool = nullptr;
     int n_threads;
 
-    void get_ggml_node_data(struct ggml_tensor * output_tensor, float * output, const size_t output_size, ggml_backend_buffer_t buffer = nullptr);
+    void get_ggml_node_data(struct ggml_tensor * output_tensor, float * output, size_t output_size, ggml_backend_buffer_t buffer = nullptr);
     void set_threads();
     void build_schedule(size_t max_nodes);
     bool prep_schedule(ggml_cgraph * gf);

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -31,7 +31,8 @@ struct runner_context {
     ggml_backend_sched_t sched = nullptr;
     ggml_threadpool_t threadpool = nullptr;
     int n_threads;
-    
+
+    void get_ggml_node_data(struct ggml_tensor * output_tensor, float * output, const size_t output_size, ggml_backend_buffer_t buffer = nullptr);
     void set_threads();
     void build_schedule(size_t max_nodes);
     bool prep_schedule(ggml_cgraph * gf);


### PR DESCRIPTION
Given the anomalous behavior which over-reading the buffer can result in, I believe it makes sense to be more protective with how TTS.cpp reads its outputs. 

I red-greened this pre and post [bb14390b5b473608d8c7ce8ec40fb3efaba4c469](https://github.com/mmwillet/TTS.cpp/pull/41/commits/bb14390b5b473608d8c7ce8ec40fb3efaba4c469).

In the long run it may make sense to refactor buffer alloc as well, but this should suffice for now.