### PR TITLE
Add's basic CPU + Metal support for Dia TTS Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In this endeavor, MacOS and metal support will be treated as the primary platfor
 | [Parler TTS Mini](https://huggingface.co/parler-tts/parler-tts-mini-v1)  |&check;|&check;|&check;|[here](https://huggingface.co/mmwillet2/Parler_TTS_GGUF)|
 | [Parler TTS Large](https://huggingface.co/parler-tts/parler-tts-large-v1)|&check;|&check;|&check;|[here](https://huggingface.co/mmwillet2/Parler_TTS_GGUF)|
 | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M)                      |&check;|&cross;|&cross;|[here](https://huggingface.co/mmwillet2/Kokoro_GGUF)    |
+| [Dia](https://github.com/nari-labs/dia)                                  |&check;|&check;|&cross;|[here](https://huggingface.co/mmwillet2/Dia_GGUF)       |
 
 Additional Model support will initially be added based on open source model performance in the [TTS model arena](https://huggingface.co/spaces/TTS-AGI/TTS-Arena) and the availability of said models' architectures and checkpoints.
 
@@ -62,7 +63,7 @@ The CLI executable and other exceutables will be in the `./build` directory (e.g
 
 If you wish to install TTS.cpp with Espeak-ng phonemization support, first [install Espeak-ng](https://github.com/espeak-ng/espeak-ng/blob/master/docs/guide.md). Depending on your installation method the path of the installed library will vary. Upon identifying the installation path to espeak-ng (it should contain `./lib`, `./bin`, `./include`, and `./share` directories), you can compile TTS.cpp with espeak phonemization support by running the follwing in the repositories base directory:
 
-```commandline
+```bash
 export ESPEAK_INSTALL_DIR=/absolute/path/to/espeak-ng/dir
 cmake -B build
 cmake --build build --config Release

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -10,7 +10,7 @@ This simple example cli tool can be used to generate speach from a text prompt a
 ### Usage
 
 In order to get a detailed breakdown the functionality currently available you can call the cli with the `--help` parameter. This will return a breakdown of all parameters:
-```commandline
+```bash
 ./cli --help
 
 --temperature (-t):
@@ -21,6 +21,8 @@ In order to get a detailed breakdown the functionality currently available you c
     The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined then it defaults to 1.
 --topk (-tk):
     (OPTIONAL) When set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.
+--max-tokens (-mt):
+    (OPTIONAL) The max audio tokens to generate. Only applied to Dia generation. If set to zero as is its default then the default max generation size
 --use-metal (-m):
     (OPTIONAL) Whether to use metal acceleration
 --no-cross-attn (-ca):
@@ -42,20 +44,28 @@ In order to get a detailed breakdown the functionality currently available you c
 --voice (-v):
     (OPTIONAL) The voice to use to generate the audio. This is only used for models with voice packs.
 --espeak-voice-id (-eid):
-    (OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice (see MultiLanguage Configuration in the README for more info).
+    (OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice ( see MultiLanguage Configuration in the README for more info).
 ```
 
 General usage should follow from these possible parameters. E.G. The following command will save generated speech to the `/tmp/test.wav` file.
 
-```commandline
+```bash
 ./cli --model-path /model/path/to/gguf_file.gguf --prompt "I am saying some words" --save-path /tmp/test.wav
+```
+
+#### Dia Generation Arguments
+
+Currently the default cli arguments are not aligned with Dia's default sampling settings. Specifically the temperature and topk settings should be changed to  `1.3` and `35` respectively when generating with Dia like so:
+
+```base
+./cli --model-path /model/path/to/Dia.gguf --prompt "[S1] Hi, I am Dia, this is how I talk." --save-path /tmp/test.wav --topk 35 --temperature 1.3
 ```
 
 #### Conditional Generation
 
 By default the Parler TTS model is saved to the GGUF format with a pre-encoded conditional prompt (i.e. a prompt used to determine how to generate speech), but if the text encoder model, the T5-Encoder model, is avaiable in gguf format (see the [python convertion scripts](../../py-gguf/README.md) for more information on how to prepare the T5-Encoder model) then a new conditional prompt can be used for generation like so:
 
-```commandline
+```bash
 ./cli --model-path /model/path/to/gguf_file.gguf --prompt "I am saying some words" --save-path /tmp/test.wav --text-encoder-path /model/path/to/t5_encoder_file.gguf --consditional-prompt "deep voice"
 ```
 
@@ -88,7 +98,7 @@ Each voice has a language assigned and gender assigned to it where the first let
 
 By default when a voice of a specific language is used, phonemization for that language will be automatically detected. However, when multiple phonetic alphabets exist for a single language the default phonemization language might not be appropriate (e.g. Mandarin latin as english is standard for Mandarin, but Pinyin might be preferred). In such cases it is necessary to specify the specific espeak-ng voice file id via the `--espeak-voice-id` argument. A comprehensive list of viable voice ids for this field can be found under the `file` column via the following espeak command:
 
-```commandline
+```bash
 espeak-ng --voices
 ```
 

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -11,7 +11,7 @@ int main(int argc, const char ** argv) {
     int default_n_threads = std::max((int)std::thread::hardware_concurrency(), 1);
     int default_top_k = 50;
     int default_max_tokens = 0;
-    float default_repetition_penalty = 1.1f;
+    float default_repetition_penalty = 1.0f;
     arg_list args;
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.", "-mp", true));
     args.add_argument(string_arg("--prompt", "(REQUIRED) The text prompt for which to generate audio in quotation markers.", "-p", true));
@@ -27,7 +27,7 @@ int main(int argc, const char ** argv) {
     args.add_argument(string_arg("--voice", "(OPTIONAL) The voice to use to generate the audio. This is only used for models with voice packs.", "-v", false, "af_alloy"));
     args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TSS). By default, no VAD is applied.", "-va"));
     args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice ( see MultiLanguage Configuration in the README for more info).", "-eid", false));
-    args.add_argument(int_arg("--max-tokens", "(OPTIONAL) The max audio tokens to generate. Only applied to Dia generation. If set to zero as is its default then the default max generation size", "-mt", false, &default_max_tokens));
+    args.add_argument(int_arg("--max-tokens", "(OPTIONAL) The max audio tokens or token batches to generate where each represents approximates 11 ms of audio. Only applied to Dia generation. If set to zero as is its default then the default max generation size. Warning values under 15 are not supported.", "-mt", false, &default_max_tokens));
     register_play_tts_response_args(args);
     args.parse(argc, argv);
     if (args.for_help) {

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -10,7 +10,8 @@ int main(int argc, const char ** argv) {
     float default_temperature = 1.0f;
     int default_n_threads = std::max((int)std::thread::hardware_concurrency(), 1);
     int default_top_k = 50;
-    float default_repetition_penalty = 1.0f;
+    int default_max_tokens = 0;
+    float default_repetition_penalty = 1.1f;
     arg_list args;
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.", "-mp", true));
     args.add_argument(string_arg("--prompt", "(REQUIRED) The text prompt for which to generate audio in quotation markers.", "-p", true));
@@ -26,6 +27,7 @@ int main(int argc, const char ** argv) {
     args.add_argument(string_arg("--voice", "(OPTIONAL) The voice to use to generate the audio. This is only used for models with voice packs.", "-v", false, "af_alloy"));
     args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TSS). By default, no VAD is applied.", "-va"));
     args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice ( see MultiLanguage Configuration in the README for more info).", "-eid", false));
+    args.add_argument(int_arg("--max-tokens", "(OPTIONAL) The max audio tokens to generate. Only applied to Dia generation. If set to zero as is its default then the default max generation size", "-mt", false, &default_max_tokens));
     register_play_tts_response_args(args);
     args.parse(argc, argv);
     if (args.for_help) {
@@ -47,7 +49,8 @@ int main(int argc, const char ** argv) {
         *args.get_float_param("--temperature"), 
         *args.get_float_param("--repetition-penalty"), 
         !args.get_bool_param("--no-cross-attn"),
-        args.get_string_param("--espeak-voice-id"));
+        args.get_string_param("--espeak-voice-id"),
+        *args.get_int_param("--max-tokens"));
 
     struct tts_runner * runner = runner_from_file(args.get_string_param("--model-path"), *args.get_int_param("--n-threads"), config, !args.get_bool_param("--use-metal"));
 

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -531,7 +531,7 @@ int main(int argc, const char ** argv) {
         struct simple_text_prompt_task * task = new simple_text_prompt_task(TTS, prompt);
         int id = task->id;
         generation_configuration * conf = new generation_configuration();
-        std::memcpy(conf, default_generation_config, sizeof(generation_configuration));
+        std::memcpy((void*)conf, default_generation_config, sizeof(generation_configuration));
         float temp;
         float rep_pen;
         int top_k;

--- a/include/common.h
+++ b/include/common.h
@@ -17,11 +17,13 @@ struct tts_response {
 enum tts_arch {
 	PARLER_TTS_ARCH = 0,
 	KOKORO_ARCH = 1,
+	DIA_ARCH = 2,
 };
 
 const std::map<std::string, tts_arch> SUPPORTED_ARCHITECTURES = {
 	{ "parler-tts", PARLER_TTS_ARCH },
 	{ "kokoro", KOKORO_ARCH },
+	{ "dia", DIA_ARCH },
 };
 
 struct generation_configuration {
@@ -32,12 +34,14 @@ struct generation_configuration {
     	float repetition_penalty = 1.0, 
     	bool use_cross_attn = true, 
     	std::string espeak_voice_id = "",
-    	bool sample = true): top_k(top_k), temperature(temperature), repetition_penalty(repetition_penalty), use_cross_attn(use_cross_attn), sample(sample), voice(voice), espeak_voice_id(espeak_voice_id) {};
+    	int max_tokens = 0,
+    	bool sample = true): top_k(top_k), temperature(temperature), repetition_penalty(repetition_penalty), use_cross_attn(use_cross_attn), sample(sample), voice(voice), espeak_voice_id(espeak_voice_id), max_tokens(max_tokens) {};
 
     bool use_cross_attn;
     float temperature;
     float repetition_penalty;
     int top_k;
+    int max_tokens;
     std::string voice = "";
     bool sample = true;
     std::string espeak_voice_id = "";

--- a/include/phonemizer.h
+++ b/include/phonemizer.h
@@ -309,9 +309,6 @@ enum phonemizer_type {
 std::string parse_voice_code(std::string voice_code);
 void update_voice(std::string voice_code);
 const std::unordered_set<std::string> inline_combine_sets(const std::vector<std::unordered_set<std::string>> sets);
-std::string strip(std::string target, std::string vals = " ");
-std::vector<std::string> split(std::string target, std::string split_on, bool include_split_characters = false);
-std::vector<std::string> split(std::string target, const char split_on, bool include_split_characters = false);
 int upper_count(std::string word);
 bool is_all_upper(std::string word);
 bool is_roman_numeral(char letter);

--- a/include/tts.h
+++ b/include/tts.h
@@ -3,11 +3,13 @@
 
 #include "parler_model.h"
 #include "kokoro_model.h"
+#include "dia_model.h"
 #include <thread>
 #include <fstream>
 
 struct tts_runner * parler_tts_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
 struct tts_runner * kokoro_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
+struct tts_runner * dia_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
 struct tts_runner * runner_from_file(const std::string & fname, int n_threads, generation_configuration * config, bool cpu_only = true);
 int generate(tts_runner * runner, std::string sentence, struct tts_response * response, generation_configuration * config);
 void update_conditional_prompt(tts_runner * runner, const std::string file_path, const std::string prompt, bool cpu_only = true);

--- a/py-gguf/convert_dia_to_gguf
+++ b/py-gguf/convert_dia_to_gguf
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import argparse
+from tts_encoders import DiaEncoder, DEFAULT_DIA_REPO_ID
+from os.path import isdir, dirname
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save-path", type=str, required=True, help="the path to save the converted gguf tts model too.")
+    parser.add_argument("--repo-id", type=str, required=False, default=DEFAULT_DIA_REPO_ID, help="A custom Huggingface repository to pull the model from.")
+    parser.add_argument("--never-make-dirs", default=False, action="store_true", help="When set the script will never add new directories.")
+    return parser.parse_known_args()
+
+
+if __name__ == '__main__':
+    args, _ = parse_arguments()
+    if not isdir(dirname(args.save_path)) and args.never_make_dirs:
+        raise ValueError(f"model path, {args.save_path} is not a valid path.")
+    DiaEncoder(args.save_path, repo_id=args.repo_id).write()

--- a/py-gguf/requirements.txt
+++ b/py-gguf/requirements.txt
@@ -1,8 +1,18 @@
 torch>=2.4.0
 torchaudio>=2.4.0
 gguf==0.10.0
-kokoro==0.8.4
+spacy==3.8.5
+kokoro==0.9.4
 huggingface-hub>=0.26.5
 transformers>=4.43.3
 parler_tts @ git+https://github.com/huggingface/parler-tts.git@8e465f1b5fcd223478e07175cb40494d19ffbe17
 gguf==0.10.0
+safetensors==0.5.3
+groovy==0.1.2
+gradio==5.29.0
+gradio-client==1.10.0
+llvmlite==0.44.0
+numba==0.61.2
+scipy>=1.15.2
+soundfile>=0.13.1
+nari-tts @ git+https://github.com/nari-labs/dia.git@7cf50c889c6013f74326cbdcb7696a985a4cf9c1

--- a/py-gguf/tts_encoders/__init__.py
+++ b/py-gguf/tts_encoders/__init__.py
@@ -3,3 +3,5 @@ from .tensor_util import *
 from .parler_tts_gguf_encoder import *
 from .t5_encoder_gguf_encoder import *
 from .kokoro_gguf_encoder import *
+from .dia_gguf_encoder import *
+from .dac_gguf_encoder import *

--- a/py-gguf/tts_encoders/dac_gguf_encoder.py
+++ b/py-gguf/tts_encoders/dac_gguf_encoder.py
@@ -1,0 +1,110 @@
+from .tts_encoder import TTSEncoder
+from .tensor_util import get_regularized_weight
+
+# DAC_RESIDUAL_UNIT_PARTS, DAC_DECODER_PARTS, DAC_DECODER_BLOCK_PARTS are static mappings
+# of the pytorch DAC Model parameter names to easily interpretable TTS.cpp names (saved to the
+# GGUF file).
+DAC_RESIDUAL_UNIT_PARTS = {
+    "block.0.alpha": "res.initial.alpha",
+    "block.1.bias": "res.initial.bias",
+    "block.1.weight": "res.initial.weight",
+    "block.2.alpha": "res.final.alpha",
+    "block.3.bias": "res.final.bias",
+    "block.3.weight": "res.final.weight",
+}
+
+DAC_DECODER_PARTS = {
+    'model.0.bias': "initial.bias",
+    'model.0.weight': "initial.weight",
+    'model.1': "decoder_block.1",
+    'model.2': "decoder_block.2",
+    'model.3': "decoder_block.3",
+    'model.4': "decoder_block.4",
+    "model.5.alpha": "final.alpha",
+    'model.6.bias': "final.bias",
+    'model.6.weight': "final.weight",
+}
+
+DAC_DECODER_BLOCK_PARTS = {
+    "block.2": "residual_unit.0",
+    "block.3": "residual_unit.1",
+    "block.4": "residual_unit.2",
+    "block.0.alpha": "final.alpha",
+    "block.1.bias": "final.bias",
+    "block.1.weight": "final.weight",
+}
+
+
+class DACEncoder(TTSEncoder):
+    @property
+    def dac_model(self):
+        raise NotImplementedError("Implmentations of 'DACEncoder' must define #dac_model.")
+
+    def prepare_dac_audio_encoder_tensors(self):
+        """
+        Prepares and writes the tensors for the DAC audio encoder model used post-generation to conform TTS outputs
+        into audio format to the GGUF file writer.
+        """
+        modules = {name: module for name, module in self.dac_model.decoder.named_modules()}
+        for name, param in self.dac_model.decoder.named_parameters():
+            name_parts = name.split(".")
+            if name_parts[-1] == "weight_g":
+                param = get_regularized_weight(modules, name)
+                name_parts[-1] = "weight"
+                name = ".".join(name_parts)
+            elif name_parts[-1] == "weight_v":
+                # ignore because we will encode the weight when we see the weight_g param
+                continue
+            parts = name.split(".block")
+            new_name = ["audio_encoder"]
+            for i, part in enumerate(parts):
+                part = f"block{part}" if i > 0 else part
+                if i == 0:
+                    if part not in DAC_DECODER_PARTS:
+                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
+                        raise ValueError(f"Part {part} is not in DAC_ENCODER_PARTS.")
+                    new_name.append(DAC_DECODER_PARTS[part])
+                elif i == 1:
+                    if part not in DAC_DECODER_BLOCK_PARTS:
+                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
+                        raise ValueError(f"Part {part} is not in DAC_ENCODER_BLOCK_PARTS.")
+                    new_name.append(DAC_DECODER_BLOCK_PARTS[part])
+                elif i == 2:
+                    if part not in DAC_RESIDUAL_UNIT_PARTS:
+                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
+                        raise ValueError(f"Part {part} is not in DAC_RESIDUAL_UNIT_PARTS.")
+                    new_name.append(DAC_RESIDUAL_UNIT_PARTS[part])
+                else:
+                    self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
+                    raise ValueError(f"DAC tensor '{name}' cannot be interpreted or encoded by {self.__class__}.")
+            new_name = ".".join(new_name)
+            self.set_tensor(new_name, param)
+
+        modules = {name: module for name, module in self.dac_model.quantizer.named_modules()}
+        for name, param in self.dac_model.quantizer.named_parameters():
+            if "in_proj" in name:
+                # the input projection for the quantized layers is only used when encoding audio not decoding.
+                continue
+            name_parts = name.split(".")
+            if name_parts[-1] == "weight_g":
+                param = get_regularized_weight(modules, name)
+                name_parts[-1] = "weight"
+                name = ".".join(name_parts)
+            elif name_parts[-1] == "weight_v":
+                # ignore because we will encode the weight when we see the weight_g param
+                continue
+            new_name = f"audio_encoder.{name}"
+            self.set_tensor(new_name, param)
+
+    def set_dac_config(self, bos_token_id: int, eos_token_id: int):
+        # ---- DAC Audio Encoder configuration ----
+        # the upscaling factor represents the input to output upscale rate in the DAC Audio encoder.
+        # It is static for all versions of DAC used by Parler-TTS
+        self.gguf_writer.add_uint32("dac.up_scaling_factor", 512)
+        for i in range(4):
+            self.gguf_writer.add_uint32(f"dac.dac_layer_stride_{i}", self.dac_model.decoder.model[i+1].block[1].stride[0])
+            self.gguf_writer.add_uint32(f"dac.dac_layer_padding_{i}", self.dac_model.decoder.model[i+1].block[1].padding[0])
+
+        # DAC audio token configuration
+        self.gguf_writer.add_uint32(f"audio.bos_token_id", bos_token_id)
+        self.gguf_writer.add_uint32(f"audio.eos_token_id", eos_token_id)

--- a/py-gguf/tts_encoders/dia_gguf_encoder.py
+++ b/py-gguf/tts_encoders/dia_gguf_encoder.py
@@ -1,0 +1,200 @@
+import gguf
+from pathlib import Path
+import torch
+from .dac_gguf_encoder import DACEncoder
+from dia.model import Dia
+from dia.state import EncoderInferenceState
+from dia.layers import DiaModel
+
+# The default repositories from which to pull the Dia torch model.
+DEFAULT_DIA_REPO_ID = "nari-labs/Dia-1.6B"
+
+# The architecture string used by TTS.cpp to assign the appropriate TTS Model and Runner.
+DIA_ARCHITECTURE = "dia"
+
+
+class DiaEncoder(DACEncoder):
+    """
+    The purpose of this class is to encode and write the tensors and model configuration for the Dia Text to Speech
+    model into a GGUF file for TTS.cpp.
+
+    General usage:
+
+    ```python
+    from tts_encoders import DiaEncoder, DEFAULT_DIA_REPO_ID
+
+    gguf_encoder = DiaEncoder("some/local/path.gguf", DEFAULT_DIA_REPO_ID)
+    gguf_encoder.write()
+    ```
+    """
+    def __init__(self, model_path: Path | str = "./dia.gguf", repo_id: Path | str = DEFAULT_DIA_REPO_ID):
+        """
+        :param Path or str model_path: the path to save the GGUF file.
+        :param Path or str repo_id: the hugging face repo or local path from which to load the pytorch Dia model.
+        """
+        super().__init__(model_path = model_path, architecture = DIA_ARCHITECTURE)
+        self.repo_id = repo_id
+        self._tokenizer = None
+        self._model = None
+
+    @property
+    def model(self) -> DiaModel:
+        if self._model is None:
+            try:
+                self._model = Dia.from_pretrained(self.repo_id, compute_dtype="float32")
+            except Exception as e:
+                self.logger.exception(
+                    f"Failed with exception, {e}, when attempting to obtain Dia at path or repo: '{self.repo_id}'"
+                )
+                raise e
+        return self._model.model
+
+    @property
+    def dac_model(self):
+        if self._model is None:
+            try:
+                self._model = Dia.from_pretrained(self.repo_id, compute_dtype="float32")
+            except Exception as e:
+                self.logger.exception(
+                    f"Failed with exception, {e}, when attempting to obtain Dia at path or repo: '{self.repo_id}'"
+                )
+                raise e
+        return self._model.dac_model
+
+
+    def prepare_tensors(self):
+        """
+        Implementation of TTSEncoder's Abstract method see TTSEncoder for more information
+        """
+        self.prepare_decoder_tensors()
+        self.prepare_encoder_tensors()
+        self.prepare_dac_audio_encoder_tensors()
+
+    def prepare_decoder_tensors(self):
+        """
+        Prepares and writes the tensors for the Dia decoder to the GGUF file writer.
+        """
+        base = "dia.decoder"
+        for name, param in self.model.decoder.named_parameters():
+            parts = name.split(".")
+            if parts[0] == "embeddings":
+                self.set_tensor(f"{base}.{parts[0]}.{parts[1]}", param)
+            elif parts[0] == "norm":
+                self.set_tensor(f"{base}.norm", param)
+            elif parts[0] == "logits_dense":
+                heads = param.shape[1];
+                for i in range(heads):
+                    head = param.data[:, i]
+                    self.set_tensor(f"{base}.heads.{i}", head.transpose(0,1))
+            elif parts[0] == "layers":
+                nn = f"{base}.{parts[0]}.{parts[1]}"
+                if (parts[2] == "mlp" and parts[3] == "wi_fused"):
+                    # the typical MLP gate and up layers are fused together in Dia's implementation, so we split them and separately encode them.
+                    gate = param.data[:, 0]
+                    up = param.data[:, 1]
+                    self.set_tensor(f"{nn}.gate", gate.transpose(0,1))
+                    self.set_tensor(f"{nn}.up", up.transpose(0,1))
+                elif parts[2] == "mlp":
+                    self.set_tensor(f"{nn}.{parts[3]}", param.data.transpose(0, 1))
+                elif parts[2] == "self_attention":
+                    data = param.data.reshape(param.shape[0], -1).transpose(0, 1)
+                    if parts[3] == "o_proj":
+                        data = param.data.reshape(-1, param.shape[-1]).transpose(0, 1)
+                    self.set_tensor(f"{nn}.self_{parts[3]}", data)
+                elif parts[2] == "cross_attention":
+                    data = param.data.reshape(param.shape[0], -1).transpose(0, 1)
+                    if parts[3] == "o_proj":
+                        data = param.data.reshape(-1, param.shape[-1]).transpose(0, 1)
+                    self.set_tensor(f"{nn}.cross_{parts[3]}", data)
+                else:
+                    self.set_tensor(f"{nn}.{parts[2]}", param)
+
+    def prepare_encoder_tensors(self):
+        """
+        Prepares and writes the tensors for the Dia encoder to the GGUF file writer.
+        """
+        base = "dia.encoder"
+        for name, param in self.model.encoder.named_parameters():
+            parts = name.split(".")
+            if parts[0] == "embedding":
+                self.set_tensor(f"{base}.embedding", param)
+            elif parts[0] == "norm":
+                self.set_tensor(f"{base}.norm", param)
+            elif parts[0] == "layers":
+                nn = f"{base}.{parts[0]}.{parts[1]}"
+                if (parts[2] == "mlp" and parts[3] == "wi_fused"):
+                    # the typical MLP gate and up layers are fused together in Dia's implementation, so we split them and separately encode them.
+                    gate = param.data[:, 0]
+                    up = param.data[:, 1]
+                    self.set_tensor(f"{nn}.gate", gate.transpose(0,1))
+                    self.set_tensor(f"{nn}.up", up.transpose(0,1))
+                elif parts[2] == "mlp":
+                    self.set_tensor(f"{nn}.{parts[3]}", param.data.transpose(0, 1))
+                elif parts[2] == "self_attention":
+                    data = param.data.reshape(param.shape[0], -1).transpose(0, 1)
+                    if parts[3] == "o_proj":
+                        data = param.data.reshape(-1, param.shape[-1]).transpose(0,1)
+                    self.set_tensor(f"{nn}.{parts[3]}", data)
+                else:
+                    self.set_tensor(f"{nn}.{parts[2]}", param)
+
+
+    def prepare_metadata(self):
+        """
+        Implementation of TTSEncoder's Abstract method see TTSEncoder for more information
+        """
+        total_params, shared_params, expert_params, expert_count = self.gguf_writer.get_total_parameter_count()
+        self.metadata = gguf.Metadata.load(None, None, self.repo_id, total_params)
+
+        # Generate parameter weight class (useful for leader boards) if not yet determined
+        if self.metadata.size_label is None and total_params > 0:
+            self.metadata.size_label = gguf.size_label(total_params, shared_params, expert_params, expert_count)
+
+        self.set_type()
+        self.set_gguf_parameters()
+        self.metadata.set_gguf_meta_model(self.gguf_writer)
+        self.gguf_writer.add_quantization_version(gguf.GGML_QUANT_VERSION)
+
+    def set_gguf_parameters(self):
+        """
+        The purpose of this function is to add general model configuration to the GGUF file writer.
+        """
+        self.set_dac_config(self.model.config.data.audio_bos_value, self.model.config.data.audio_eos_value);
+
+        # ---- Dia Configuration ----
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.attn_head_size", self.model.config.model.encoder.head_dim)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.eos_token_id", self.model.config.data.audio_eos_value)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.bos_token_id", self.model.config.data.audio_bos_value)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.pad_token_id", self.model.config.data.audio_pad_value)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.max_delay", max(self.model.config.data.delay_pattern))
+
+
+        # ---- Dia Encoder Configuration ----
+        # Overwrite the architecture so that encoder config is stored appropriately under the encoder context in the GGUF file.
+        self.gguf_writer.arch = f"{DIA_ARCHITECTURE}.encoder"
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.max_context_length", self.model.config.data.text_length)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.attn_heads", self.model.config.model.encoder.n_head)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.layers", self.model.config.model.encoder.n_layer)
+
+        # ---- Dia Decoder Configuration ----
+        # Overwrite the architecture so that encoder config is stored appropriately under the decoder context in the GGUF file.
+        self.gguf_writer.arch = f"{DIA_ARCHITECTURE}.decoder"
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.hidden_size", self.model.config.model.decoder.n_embd)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.layers", self.model.config.model.decoder.n_layer)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.output_heads", self.model.config.data.channels)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.attn_heads", self.model.config.model.decoder.gqa_query_heads)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.query_heads", self.model.config.model.decoder.kv_heads)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.output_vocab_size", self.model.config.model.tgt_vocab_size)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.audio_vocab_size", self.model.config.data.audio_eos_value)
+        self.gguf_writer.add_uint32(f"{self.gguf_writer.arch}.max_generation_size", self.model.config.data.audio_length)
+
+        # Reset the architecture on the gguf writer
+        self.gguf_writer.arch = DIA_ARCHITECTURE
+
+        # The file type setting is purely for describing the primary precision of the model as it is stored in the GGUF file.
+        # This setting *does not* enforce the tensor format or alter tensor processing capabilities in TTS.cpp and is only
+        # used for reporting.
+        self.gguf_writer.add_file_type(gguf.LlamaFileType.ALL_F32)
+
+    def set_type(self):
+        self.gguf_writer.add_type(gguf.GGUFType.MODEL)

--- a/py-gguf/tts_encoders/parler_tts_gguf_encoder.py
+++ b/py-gguf/tts_encoders/parler_tts_gguf_encoder.py
@@ -5,41 +5,7 @@ from tokenizers.models import Unigram
 from parler_tts import ParlerTTSForConditionalGeneration
 import torch
 import json
-from .tts_encoder import TTSEncoder
-from .tensor_util import get_regularized_weight
-
-# DAC_RESIDUAL_UNIT_PARTS, DAC_DECODER_PARTS, DAC_DECODER_BLOCK_PARTS are static mappings
-# of the pytorch DAC Model parameter names to easily interpretable TTS.cpp names (saved to the
-# GGUF file).
-DAC_RESIDUAL_UNIT_PARTS = {
-    "block.0.alpha": "res.initial.alpha",
-    "block.1.bias": "res.initial.bias",
-    "block.1.weight": "res.initial.weight",
-    "block.2.alpha": "res.final.alpha",
-    "block.3.bias": "res.final.bias",
-    "block.3.weight": "res.final.weight",
-}
-
-DAC_DECODER_PARTS = {
-    'model.0.bias': "initial.bias",
-    'model.0.weight': "initial.weight",
-    'model.1': "decoder_block.1",
-    'model.2': "decoder_block.2",
-    'model.3': "decoder_block.3",
-    'model.4': "decoder_block.4",
-    "model.5.alpha": "final.alpha",
-    'model.6.bias': "final.bias",
-    'model.6.weight': "final.weight",
-}
-
-DAC_DECODER_BLOCK_PARTS = {
-    "block.2": "residual_unit.0",
-    "block.3": "residual_unit.1",
-    "block.4": "residual_unit.2",
-    "block.0.alpha": "final.alpha",
-    "block.1.bias": "final.bias",
-    "block.1.weight": "final.weight",
-}
+from .dac_gguf_encoder import DACEncoder
 
 # The default repositories from which to pull Parler TTS torch models.
 DEFAULT_PARLER_REPO_MINI_ID = "parler-tts/parler-tts-mini-v1"
@@ -52,7 +18,7 @@ PARLER_TTS_ARCHITECTURE = "parler-tts"
 DEFAULT_CONDITIONAL_PROMPT = "female voice"
 
 
-class ParlerTTSEncoder(TTSEncoder):
+class ParlerTTSEncoder(DACEncoder):
     """
     The purpose of this class is to encode and write the tensors and model configuration for the  Parler-TTS generative
     Decoder and Audio Encoder models into a GGUF file for TTS.cpp. Only the tensors necessary to Generation are handled
@@ -93,6 +59,10 @@ class ParlerTTSEncoder(TTSEncoder):
         return self._model
 
     @property
+    def dac_model(self):
+        return self.model.audio_encoder.model
+
+    @property
     def tokenizer(self) -> AutoTokenizer:
         if self._tokenizer is None:
             try:
@@ -109,7 +79,7 @@ class ParlerTTSEncoder(TTSEncoder):
         Implementation of TTSEncoder's Abstract method see TTSEncoder for more information
         """
         self.prepare_text_encoding_tensors(self.text_encoding_prompt)
-        self.prepare_audio_encoder_tensors()
+        self.prepare_dac_audio_encoder_tensors()
         self.prepare_decoder_tensors()
 
     def prepare_text_encoding_tensors(self, prompt: str):
@@ -138,62 +108,6 @@ class ParlerTTSEncoder(TTSEncoder):
         data = model_kwargs["encoder_outputs"].last_hidden_state.squeeze()
         self.set_tensor("decoder.text_encoding", data)
         self.gguf_writer.add_uint32(f"parler-tts.decoder.encode_length", data.shape[0])
-
-    def prepare_audio_encoder_tensors(self):
-        """
-        Prepares and writes the tensors for the DAC audio encoder model used post-generation to conform Parler-TTS
-        into audio format to the GGUF file writer.
-        """
-        modules = {name: module for name, module in self.model.audio_encoder.model.decoder.named_modules()}
-        for name, param in self.model.audio_encoder.model.decoder.named_parameters():
-            name_parts = name.split(".")
-            if name_parts[-1] == "weight_g":
-                param = get_regularized_weight(modules, name)
-                name_parts[-1] = "weight"
-                name = ".".join(name_parts)
-            elif name_parts[-1] == "weight_v":
-                # ignore because we will encode the weight when we see the weight_g param
-                continue
-            parts = name.split(".block")
-            new_name = ["audio_encoder"]
-            for i, part in enumerate(parts):
-                part = f"block{part}" if i > 0 else part
-                if i == 0:
-                    if part not in DAC_DECODER_PARTS:
-                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
-                        raise ValueError(f"Part {part} is not in DAC_ENCODER_PARTS.")
-                    new_name.append(DAC_DECODER_PARTS[part])
-                elif i == 1:
-                    if part not in DAC_DECODER_BLOCK_PARTS:
-                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
-                        raise ValueError(f"Part {part} is not in DAC_ENCODER_BLOCK_PARTS.")
-                    new_name.append(DAC_DECODER_BLOCK_PARTS[part])
-                elif i == 2:
-                    if part not in DAC_RESIDUAL_UNIT_PARTS:
-                        self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
-                        raise ValueError(f"Part {part} is not in DAC_RESIDUAL_UNIT_PARTS.")
-                    new_name.append(DAC_RESIDUAL_UNIT_PARTS[part])
-                else:
-                    self.logger.exception(f"Found unexpected tensor in DAC model, '{name}'.")
-                    raise ValueError(f"DAC tensor '{name}' cannot be interpreted or encoded by {self.__class__}.")
-            new_name = ".".join(new_name)
-            self.set_tensor(new_name, param)
-
-        modules = {name: module for name, module in self.model.audio_encoder.model.quantizer.named_modules()}
-        for name, param in self.model.audio_encoder.model.quantizer.named_parameters():
-            if "in_proj" in name:
-                # the input projection for the quantized layers is only used when encoding audio not decoding.
-                continue
-            name_parts = name.split(".")
-            if name_parts[-1] == "weight_g":
-                param = get_regularized_weight(modules, name)
-                name_parts[-1] = "weight"
-                name = ".".join(name_parts)
-            elif name_parts[-1] == "weight_v":
-                # ignore because we will encode the weight when we see the weight_g param
-                continue
-            new_name = f"audio_encoder.{name}"
-            self.set_tensor(new_name, param)
 
     def prepare_decoder_tensors(self):
         """
@@ -238,19 +152,7 @@ class ParlerTTSEncoder(TTSEncoder):
         """
         self.gguf_writer.add_pad_token_id(self.model.config.pad_token_id)
         self.gguf_writer.add_decoder_start_token_id(self.model.config.decoder_start_token_id)
-
-        # ---- DAC Audio Encoder configuration ----
-
-        # the upscaling factor represents the input to output upscale rate in the DAC Audio encoder.
-        # It is static for all versions of DAC used by Parler-TTS
-        self.gguf_writer.add_uint32("dac.up_scaling_factor", 512)
-        for i in range(4):
-            self.gguf_writer.add_uint32(f"dac.dac_layer_stride_{i}", self.model.audio_encoder.model.decoder.model[i+1].block[1].stride[0])
-            self.gguf_writer.add_uint32(f"dac.dac_layer_padding_{i}", self.model.audio_encoder.model.decoder.model[i+1].block[1].padding[0])
-
-        # DAC audio token configuration
-        self.gguf_writer.add_uint32(f"audio.bos_token_id", self.model.decoder.config.bos_token_id)
-        self.gguf_writer.add_uint32(f"audio.eos_token_id", self.model.decoder.config.eos_token_id)
+        self.set_dac_config(self.model.decoder.config.bos_token_id, self.model.decoder.config.eos_token_id);
 
         # ---- Parler TTS Decoder configuration ----
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(tts
             phonemizer.cpp
             tts_model.cpp
             kokoro_model.cpp
+            dia_model.cpp
             )
 
 target_include_directories(tts PUBLIC . ../include ../ggml/src/)

--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -26,7 +26,7 @@ static const std::map<std::string, dac_tensor> DAC_TENSOR_GGUF_LOOKUP = {
 };
 
 void dac_model::prep_constants(gguf_context * meta) {
-    int output_heads_key = search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads", "output_heads"});
+    int output_heads_key = search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads", "output_heads", "dia.decoder.outpu_heads"});
     if (output_heads_key != -1) {
         n_heads = gguf_get_val_u32(meta, output_heads_key);;
     }
@@ -36,7 +36,7 @@ void dac_model::prep_constants(gguf_context * meta) {
         up_sampling_factor = gguf_get_val_u32(meta, sampling_factor_key);
     }
     
-    int max_gen_key = search_for_gguf_keys(meta, {"parler-tts.decoder.max_generation", "max_generation"});
+    int max_gen_key = search_for_gguf_keys(meta, {"parler-tts.decoder.max_generation", "max_generation", "dia.decoder.max_generation"});
     if (max_gen_key != -1) {
         max_generation_size = gguf_get_val_u32(meta, max_gen_key);
     }

--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -26,7 +26,7 @@ static const std::map<std::string, dac_tensor> DAC_TENSOR_GGUF_LOOKUP = {
 };
 
 void dac_model::prep_constants(gguf_context * meta) {
-    int output_heads_key = search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads", "output_heads", "dia.decoder.outpu_heads"});
+    int output_heads_key = search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads", "output_heads", "dia.decoder.output_heads"});
     if (output_heads_key != -1) {
         n_heads = gguf_get_val_u32(meta, output_heads_key);;
     }

--- a/src/dia_model.cpp
+++ b/src/dia_model.cpp
@@ -1,0 +1,890 @@
+#include "dia_model.h"
+
+void dia_model::assign_weight(std::string name, struct ggml_tensor * tensor) {
+    std::vector<std::string> parts = split(name, ".");
+    TTS_ASSERT(parts.size() >= 3);
+
+    if (parts[1] == "encoder") {
+        assign_to_encoder(parts, tensor, name);
+    } else if (parts[1] == "decoder"){
+        assign_to_decoder(parts, tensor, name);
+    } else {
+        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
+    }
+}
+
+void dia_model::assign_to_encoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name) {
+    if (parts[2] == "embedding") {
+        encoder->embedding = ggml_dup_tensor(ctx, tensor);
+        set_tensor(encoder->embedding, tensor);
+    } else if (parts[2] == "norm") {
+        encoder->norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(encoder->norm, tensor);
+    } else if (parts[2] == "layers") {
+        TTS_ASSERT(parts.size() >= 4);
+        int index = std::stoi(parts[3]);
+        TTS_ASSERT(index < decoder->layers.size());
+        assign_to_encoder_layer(parts[4], encoder->layers[index], tensor);
+    } else {
+        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
+    }
+}
+
+void dia_model::assign_to_decoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name) {
+    if (parts[2] == "embeddings") {
+        TTS_ASSERT(parts.size() > 2);
+        int index = std::stoi(parts[3]);
+        TTS_ASSERT(index < decoder->embds.size());
+        decoder->embds[index] = ggml_dup_tensor(ctx, tensor);
+        set_tensor(decoder->embds[index], tensor);
+    } else if (parts[2] == "norm") {
+        decoder->norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(decoder->norm, tensor);
+    } else if (parts[2] == "heads") {
+        TTS_ASSERT(parts.size() > 2);
+        int index = std::stoi(parts[3]);
+        TTS_ASSERT(index < decoder->heads.size());
+        decoder->heads[index] = ggml_dup_tensor(ctx, tensor);
+        set_tensor(decoder->heads[index], tensor);
+    } else if (parts[2] == "layers") {
+        TTS_ASSERT(parts.size() >= 4);
+        int index = std::stoi(parts[3]);
+        TTS_ASSERT(index < decoder->layers.size());
+        assign_to_decoder_layer(parts[4], decoder->layers[index], tensor);
+    } else {
+        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
+    }
+}
+
+void dia_model::assign_to_encoder_layer(std::string part, dia_encoder_layer * layer, struct ggml_tensor * tensor) {
+    if (part == "q_proj") {
+        layer->q = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->q, tensor);
+    } else if (part == "k_proj") {
+        layer->k = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->k, tensor);
+    } else if (part == "v_proj") {
+        layer->v = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->v, tensor);
+    } else if (part == "o_proj") {
+        layer->o = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->o, tensor);
+    } else if (part == "pre_sa_norm") {
+        layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_norm, tensor);
+    } else if (part == "post_sa_norm") {
+        layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->mlp_norm, tensor);
+    } else if (part == "gate") {
+        layer->gate = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->gate, tensor);
+    } else if (part == "up") {
+        layer->up = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->up, tensor);
+    } else if (part == "wo") {
+        layer->out = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->out, tensor);
+    } else {
+        TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia from GGUF file.", part.c_str());
+    }
+}
+
+void dia_model::assign_to_decoder_layer(std::string part, dia_decoder_layer * layer, struct ggml_tensor * tensor) {
+    if (part == "self_q_proj") {
+        layer->self_attn_q = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_q, tensor);
+    } else if (part == "self_k_proj") {
+        layer->self_attn_k = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_k, tensor);
+    } else if (part == "self_v_proj") {
+        layer->self_attn_v = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_v, tensor);
+    } else if (part == "self_o_proj") {
+        layer->self_attn_o = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_o, tensor);
+    } else if (part == "cross_q_proj") {
+        layer->cross_attn_q = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->cross_attn_q, tensor);
+    } else if (part == "cross_k_proj") {
+        layer->cross_attn_k = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->cross_attn_k, tensor);
+    } else if (part == "cross_v_proj") {
+        layer->cross_attn_v = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->cross_attn_v, tensor);
+    } else if (part == "cross_o_proj") {
+        layer->cross_attn_o = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->cross_attn_o, tensor);
+    } else if (part == "pre_sa_norm") {
+        layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->self_attn_norm, tensor);
+    } else if (part == "pre_mlp_norm") {
+        layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->mlp_norm, tensor);    
+    } else if (part == "pre_ca_norm") {
+        layer->cross_attn_norm = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->cross_attn_norm, tensor);
+    } else if (part == "gate") {
+        layer->gate = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->gate, tensor);
+    } else if (part == "up") {
+        layer->up = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->up, tensor);
+    } else if (part == "wo") {
+        layer->out = ggml_dup_tensor(ctx, tensor);
+        set_tensor(layer->out, tensor);
+    } else {
+        TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia from GGUF file.", part.c_str());
+    }
+}
+
+void dia_model::prep_layers() {
+    encoder = new dia_encoder;
+    decoder = new dia_decoder;
+    encoder->layers.reserve((size_t) n_encoder_layers);
+    for (int i = 0; i < (int) n_encoder_layers; i++) {
+        dia_encoder_layer * l = new dia_encoder_layer;
+        encoder->layers.push_back(l);
+    }
+
+    decoder->layers.reserve((size_t) n_decoder_layers);
+    for (int i = 0; i < (int) n_decoder_layers; i++) {
+        dia_decoder_layer * l = new dia_decoder_layer;
+        decoder->layers.push_back(l);
+    }
+    
+    decoder->embds.reserve((size_t) n_output_heads);
+    decoder->heads.reserve((size_t) n_output_heads);
+    for (int i = 0; i < n_output_heads; i++) {
+        struct ggml_tensor * h = nullptr;
+        struct ggml_tensor * embd = nullptr;
+        decoder->embds.push_back(embd);
+        decoder->heads.push_back(h);
+    }
+}
+
+void dia_model::prep_constants(gguf_context * meta) {
+    int output_heads_key = gguf_find_key(meta, "dia.decoder.output_heads");
+    if (output_heads_key != -1) {
+        n_output_heads = gguf_get_val_u32(meta, output_heads_key);
+    }
+
+    int decoder_layers_key = gguf_find_key(meta, "dia.decoder.layers");
+    if (decoder_layers_key != -1) {
+        n_decoder_layers = gguf_get_val_u32(meta, decoder_layers_key);
+    }
+
+    int encoder_layers_key = gguf_find_key(meta, "dia.encoder.layers");
+    if (encoder_layers_key != -1) {
+        n_encoder_layers = gguf_get_val_u32(meta, encoder_layers_key);
+    }
+
+    int decoder_hidden_size_key = gguf_find_key(meta, "dia.decoder.hidden_size");
+    if (decoder_hidden_size_key != -1) {
+        decoder_hidden_size = gguf_get_val_u32(meta, decoder_hidden_size_key);
+    }
+
+    int decoder_attn_heads_key = gguf_find_key(meta, "dia.decoder.attn_heads");
+    if (decoder_attn_heads_key != -1) {
+        decoder_attn_heads = gguf_get_val_u32(meta, decoder_attn_heads_key);
+    }
+
+    int decoder_query_heads_key = gguf_find_key(meta, "dia.decoder.query_heads");
+    if (decoder_query_heads_key != -1) {
+        decoder_query_heads = gguf_get_val_u32(meta, decoder_query_heads_key);
+    }
+
+    int encoder_attn_heads_key = gguf_find_key(meta, "dia.encoder.attn_heads");
+    if (encoder_attn_heads_key != -1) {
+        encoder_attn_heads = gguf_get_val_u32(meta, encoder_attn_heads_key);
+    }    
+
+    int head_size_key = gguf_find_key(meta, "dia.attn_head_size");
+    if (head_size_key != -1) {
+        head_size = gguf_get_val_u32(meta, head_size_key);
+    }
+
+    int eos_token_id_key = gguf_find_key(meta, "dia.eos_token_id");
+    if (eos_token_id_key != -1) {
+        eos_token_id = gguf_get_val_u32(meta, eos_token_id_key);
+    }
+
+    int bos_token_id_key = gguf_find_key(meta, "dia.bos_token_id");
+    if (bos_token_id_key != -1) {
+        bos_token_id = gguf_get_val_u32(meta, bos_token_id_key);
+    }
+
+    int pad_token_id_key = gguf_find_key(meta, "dia.pad_token_id");
+    if (pad_token_id_key != -1) {
+        pad_token_id = gguf_get_val_u32(meta, pad_token_id_key);
+    }
+
+    int max_context_key = gguf_find_key(meta, "dia.encoder.max_context_length");
+    if (max_context_key != -1) {
+        max_encoder_context_length = gguf_get_val_u32(meta, max_context_key);
+    }
+
+    int output_vocab_size_key = gguf_find_key(meta, "dia.decoder.output_vocab_size");
+    if (output_vocab_size_key != -1) {
+        output_vocab_size = gguf_get_val_u32(meta, output_vocab_size_key);
+    }
+
+    int audio_vocab_size_key = gguf_find_key(meta, "dia.decoder.audio_vocab_size");
+    if (audio_vocab_size_key != -1) {
+        audio_vocab_size = gguf_get_val_u32(meta, audio_vocab_size_key);
+    }
+
+    int max_generation_size_key = gguf_find_key(meta, "dia.decoder.max_generation_size");
+    if (max_generation_size_key != -1) {
+        max_generation_size = gguf_get_val_u32(meta, max_generation_size_key);
+    }
+    int max_delay_key = gguf_find_key(meta, "dia.max_delay");
+    if (max_delay_key != -1) {
+        max_delay = gguf_get_val_u32(meta, max_delay_key);
+    }
+}
+
+void dia_context::reset() {
+    current_position = 0;
+    prompt_size = 0;
+    output_tokens.clear();
+    delay_steps = -1;
+}
+
+struct dia_context * build_new_dia_context(struct dia_model * model, int n_threads, bool use_cpu) {
+    dia_context * dctx = new dia_context(model, n_threads);
+    if (!use_cpu) {
+#ifdef GGML_USE_METAL
+        dctx->backend = ggml_backend_metal_init();
+#endif
+    }
+    dctx->backend_cpu = ggml_backend_cpu_init();
+    dctx->set_threads();
+    dctx->build_schedule();
+    dctx->buf_compute_meta.resize(ggml_tensor_overhead()*model->max_nodes() + ggml_graph_overhead_custom(model->max_nodes(), false));
+    return dctx;
+}
+
+static bool dia_kv_cache_init(struct dia_kv_cache * cache, dia_model * model, dia_context * dctx) {    
+    ggml_backend_buffer_type_t buft = nullptr;
+    // this will only really support cpu or metal for the time being;
+    if (dctx->backend != nullptr) {
+#ifdef GGML_USE_METAL
+        buft = ggml_backend_metal_buffer_type();
+#endif
+    } else {
+        buft = ggml_backend_cpu_buffer_type();
+    }
+
+    struct ggml_init_params params = {
+        /*.mem_size   =*/ (4u * model->n_decoder_layers + 1) * ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context * ctx = ggml_init(params);
+    if (!ctx) {
+        return false;
+    }
+    cache->ctx = ctx;
+
+    cache->k_l.reserve(model->n_decoder_layers);
+    cache->v_l.reserve(model->n_decoder_layers);
+    cache->cross_k_l.reserve(model->n_decoder_layers);
+    cache->cross_v_l.reserve(model->n_decoder_layers);
+
+    for (int i = 0; i < (int) model->n_decoder_layers; i++) {
+        struct ggml_tensor * k = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_generation_size * 2);
+        struct ggml_tensor * v = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_generation_size * 2);
+        struct ggml_tensor * cross_k = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_encoder_context_length * 2);
+        struct ggml_tensor * cross_v = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_encoder_context_length * 2);
+        ggml_format_name(k, "cache_k_l%d", i);
+        ggml_format_name(v, "cache_v_l%d", i);
+        ggml_format_name(cross_k, "cache_cross_k_l%d", i);
+        ggml_format_name(cross_v, "cache_cross_v_l%d", i);
+        cache->k_l.push_back(k);
+        cache->v_l.push_back(v);
+        cache->cross_k_l.push_back(cross_k);
+        cache->cross_v_l.push_back(cross_v);
+    }
+
+    // allocate tensors and initialize the buffers to avoid NaNs in the padding
+    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(cache->ctx, buft);
+    if (!buf) {
+        return false;
+    }
+    ggml_backend_buffer_clear(buf, 0);
+    cache->buf = buf;
+
+    return true;
+}
+
+static struct ggml_tensor * build_dia_decoder_inp_embd(struct ggml_context * ctx, dia_context *dctx, dia_decoder * decoder, dia_ubatch & batch, uint32_t n_output_heads) {
+    struct ggml_tensor * input_embs;
+
+    dctx->audio_inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_output_heads * 2);
+    ggml_set_input(dctx->audio_inp_tokens);
+    for (int i = 0; i < n_output_heads; i++) {
+        struct ggml_tensor * view = ggml_view_1d(ctx, dctx->audio_inp_tokens, 2, i * ggml_element_size(dctx->audio_inp_tokens));
+        view->nb[0] = n_output_heads * ggml_element_size(dctx->audio_inp_tokens);
+        if (i == 0) {
+            input_embs = ggml_get_rows(ctx, decoder->embds[i], view);
+        } else {
+            input_embs = ggml_add(ctx, ggml_get_rows(ctx, decoder->embds[i], view), input_embs);
+        }
+    }
+    return input_embs;
+}
+
+static struct ggml_tensor * dia_layer_norm(struct ggml_context * ctx, struct ggml_tensor * inputs, struct ggml_tensor * weight) {
+    // dia always uses 1e-5 as the default eps
+    float eps = 0.00001;
+    inputs = ggml_rms_norm(ctx, inputs, eps);
+    return ggml_mul(ctx, inputs, weight);
+}
+
+static struct ggml_tensor * build_dia_encoder_attn_mask(ggml_context * ctx, struct dia_context * dctx, dia_model * model) {
+    dctx->encode_attn_mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, (int64_t) model->max_encoder_context_length, (int64_t) model->max_encoder_context_length);
+    ggml_set_input(dctx->encode_attn_mask);
+
+    return dctx->encode_attn_mask;
+}
+
+static struct ggml_tensor * build_dia_head_outputs(struct ggml_context * ctx, dia_model * model, struct ggml_tensor * cur) {
+    // going to cat the heads together and then reshape them
+    struct ggml_tensor * out;
+    for (int i = 0; i < model->n_output_heads; i++) {
+        if (i == 0) {
+            out = ggml_mul_mat(ctx, model->decoder->heads[i], cur);
+        } else {
+            out = ggml_concat(ctx, out, ggml_mul_mat(ctx, model->decoder->heads[i], cur), 2);
+        }
+    }
+    struct ggml_tensor * cond = ggml_cont(ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2], 0));
+    struct ggml_tensor * uncond = ggml_cont(ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2], out->nb[1]));
+    return ggml_map_custom2(ctx, cond, uncond, &cfg_scale, out->ne[0], &model->cfg_scale);
+}
+
+static struct ggml_tensor * build_dia_encoder(ggml_context * ctx, dia_model * model, dia_context * dctx, dia_ubatch & batch) {
+    dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, model->max_encoder_context_length*2);
+    ggml_set_input(dctx->inp_tokens);
+
+    dctx->encode_positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, model->max_encoder_context_length);
+    ggml_set_input(dctx->encode_positions);
+
+    struct ggml_tensor * attn_mask = build_dia_encoder_attn_mask(ctx, dctx, model);
+
+    struct ggml_tensor * cur = ggml_reshape_3d(ctx, ggml_get_rows(ctx, model->encoder->embedding, dctx->inp_tokens), model->encoder_hidden_size, model->max_encoder_context_length, 2);
+    for (auto layer : model->encoder->layers) {
+        struct ggml_tensor * residual = cur;
+        
+        cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
+        // self-attention
+        {
+            struct ggml_tensor * Qcur = ggml_mul_mat(ctx, layer->q, cur);
+            struct ggml_tensor * Kcur = ggml_mul_mat(ctx, layer->k, cur);
+            struct ggml_tensor * Vcur = ggml_mul_mat(ctx, layer->v, cur);
+
+            // Strangely Dia follows the neoX Rotary Positional Embeddings Protocol
+            Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size, model->encoder_attn_heads, model->max_encoder_context_length, 2)), dctx->encode_positions, model->head_size, 2);
+            Kcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Kcur, model->head_size, model->encoder_attn_heads, model->max_encoder_context_length, 2)), dctx->encode_positions, model->head_size, 2);
+            struct ggml_tensor * q = ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
+            struct ggml_tensor * k = ggml_cont(ctx, ggml_permute(ctx, Kcur, 0, 2, 1, 3));
+            struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
+            kq = ggml_soft_max_ext(ctx, kq, attn_mask, 1.0f, 0.0f);
+            struct ggml_tensor * v = ggml_cont_4d(ctx, ggml_transpose(ctx, Vcur), model->max_encoder_context_length, model->head_size, model->encoder_attn_heads, 2);
+            struct ggml_tensor * kqv = ggml_mul_mat(ctx, kq, v);
+            struct ggml_tensor * kqv_merged = ggml_permute(ctx, kqv, 2, 0, 1, 3);
+
+            // It is unclear why the attention ops in Dia's encoder don't project to the embedding dimension size as is standard. Instead they up project to the decoder's embedding dimension
+            // then down project back the the encoder embedding dimension. 
+            cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size, model->max_encoder_context_length, 2);
+            cur = ggml_mul_mat(ctx, layer->o, cur);
+        }
+
+        cur = ggml_add(ctx, cur, residual);
+        struct ggml_tensor * residual_mlp = cur;
+
+        cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
+        // mlp
+        {
+            cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)), ggml_mul_mat(ctx, layer->up, cur));
+            cur = ggml_mul_mat(ctx, layer->out, cur);
+        }
+
+        cur = ggml_add(ctx, cur, residual_mlp);
+    }
+
+    cur = dia_layer_norm(ctx, cur, model->encoder->norm);
+    return cur;
+}
+
+static struct ggml_tensor * repeat_interleave_dim1(ggml_context * ctx, struct ggml_tensor * a, int repeat) {
+    //return ggml_repeat(ctx, a, ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], 4*a->ne[1], a->ne[2], a->ne[3]));
+    struct ggml_tensor * running;
+    for (int i = 0; i < a->ne[1]; i++) {
+        int offset = i * a->nb[1];
+        struct ggml_tensor * t = ggml_cont(ctx, ggml_view_4d(ctx, a, a->ne[0], 1, a->ne[2], a->ne[3], a->nb[1], a->nb[2], a->nb[3], offset));
+        t = ggml_repeat(ctx, t, ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], repeat, a->ne[2], a->ne[3]));
+        if (i == 0) {
+            running = t;
+        } else {
+            running = ggml_concat(ctx, running, t, 1);
+        }
+    }
+    return running;
+}
+
+static void build_dia_self_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * k, struct ggml_tensor * v, dia_ubatch & batch, int layer_index) {
+    int64_t attn_size = model->head_size * model->decoder_attn_heads;
+
+    struct ggml_tensor * k_cache_view = 
+        ggml_view_2d(
+                ctx, kv->k_l[layer_index], attn_size, 2, 
+                attn_size * model->max_generation_size * ggml_element_size(kv->k_l[layer_index]), 
+                attn_size*dctx->current_position*ggml_element_size(kv->k_l[layer_index]));
+
+    k = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
+    // Since the sequence length should always be 1 here this is the most pertinent time to repeat the heads for grouped query attention.
+    // If GGML supported a repeat_interleave op then it would be more optimal to store just the groups in the cache and interleave the attention heads after recalling
+    // from the cache
+    k = repeat_interleave_dim1(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), model->decoder_query_heads);
+    k = ggml_cont(ctx, ggml_reshape_2d(ctx, k, attn_size, 2));
+
+    ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
+
+    struct ggml_tensor * v_cache_view = nullptr;
+
+    v_cache_view = ggml_view_2d(
+            ctx, kv->v_l[layer_index], attn_size, 2, 
+            attn_size * model->max_generation_size * ggml_element_size(kv->v_l[layer_index]), 
+            attn_size*dctx->current_position*ggml_element_size(kv->v_l[layer_index]));
+
+    // Since the sequence length should always be 1 here this is the most pertinent time to repeat the heads for grouped query attention.
+    // If GGML supported a repeat_interleave op then it would be more optimal to store just the groups in the cache and interleave the attention heads after recalling
+    // from the cache
+    v = repeat_interleave_dim1(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, v, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), model->decoder_query_heads);
+
+    ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
+}
+
+static void build_dia_cross_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * encoder_hidden_states, int layer_index) {
+    dia_decoder_layer * layer = model->decoder->layers[layer_index];
+    struct ggml_tensor * encoder_states_key_view = ggml_cont(ctx, ggml_view_3d(
+        ctx, 
+        encoder_hidden_states, 
+        model->encoder_hidden_size, 
+        dctx->prompt_size, 
+        2, 
+        model->encoder_hidden_size * ggml_element_size(encoder_hidden_states), model->encoder_hidden_size * model->max_encoder_context_length * ggml_element_size(encoder_hidden_states), 0));
+
+    struct ggml_tensor * k = ggml_mul_mat(ctx, layer->cross_attn_k, encoder_states_key_view);
+    struct ggml_tensor * positions_view = ggml_view_1d(ctx, dctx->encode_positions, dctx->prompt_size, 0);
+
+    k = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads, dctx->prompt_size, 2)), positions_view, model->head_size, 2);
+    k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 1, 3, 2));
+
+    struct ggml_tensor * k_cache_view =
+        ggml_view_4d(
+                ctx, kv->cross_k_l[layer_index], model->head_size, model->decoder_attn_heads, 2, dctx->prompt_size, 
+                model->head_size*ggml_element_size(kv->cross_k_l[layer_index]), 
+                model->head_size*model->decoder_attn_heads*ggml_element_size(kv->cross_k_l[layer_index]),
+                model->head_size*model->decoder_attn_heads*2*ggml_element_size(kv->cross_k_l[layer_index]),
+                0);
+
+    ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
+
+    struct ggml_tensor * v = ggml_cont(ctx, ggml_transpose(ctx, ggml_mul_mat(ctx, layer->cross_attn_v, encoder_hidden_states)));
+    v = ggml_cont_4d(ctx, v, model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2);
+
+    struct ggml_tensor * v_cache_view =
+        ggml_view_4d(
+                ctx, kv->cross_v_l[layer_index], model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2, 
+                model->max_encoder_context_length*ggml_element_size(kv->cross_v_l[layer_index]), 
+                model->head_size*model->max_encoder_context_length*ggml_element_size(kv->cross_v_l[layer_index]), 
+                model->head_size*model->max_encoder_context_length*model->decoder_attn_heads*ggml_element_size(kv->cross_v_l[layer_index]), 
+                0);
+
+    ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
+}
+
+static struct ggml_tensor * build_dia_decoder(
+        ggml_cgraph * gf,
+        ggml_context * ctx, 
+        dia_model * model, 
+        dia_context * dctx, 
+        dia_kv_cache * cache, 
+        dia_ubatch & batch, 
+        struct ggml_tensor * encoder_hidden_states) {
+    dctx->positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length);
+    ggml_set_input(dctx->positions);
+    struct ggml_tensor * cur = build_dia_decoder_inp_embd(ctx, dctx, model->decoder, batch, model->n_output_heads);
+
+    for (int l = 0; l < model->decoder->layers.size(); l++){
+        dia_decoder_layer * layer = model->decoder->layers[l];
+        struct ggml_tensor * residual = cur;
+        
+        cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
+        // self-attention
+        {
+            struct ggml_tensor * Qcur = ggml_mul_mat(ctx, layer->self_attn_q, cur);
+            struct ggml_tensor * Kcur = ggml_mul_mat(ctx, layer->self_attn_k, cur);
+            struct ggml_tensor * Vcur = ggml_mul_mat(ctx, layer->self_attn_v, cur);
+
+            build_dia_self_kv_store(ctx, dctx, model, cache, gf, Kcur, Vcur, batch, l);
+            struct ggml_tensor * k =
+                ggml_view_4d(ctx, cache->k_l[l],
+                        model->head_size, model->decoder_attn_heads, dctx->current_position + 1, 2,
+                        ggml_element_size(cache->k_l[l]) * model->head_size,
+                        ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads * model->head_size,
+                        ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads * model->head_size * model->max_generation_size,
+                        0);
+            k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 2, 1, 3));
+
+            struct ggml_tensor * v = 
+                ggml_view_3d(ctx, cache->v_l[l],
+                        model->head_size * model->decoder_attn_heads, dctx->current_position + 1, 2,
+                        ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads * model->head_size,
+                        ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads * model->head_size * model->max_generation_size,
+                        0);
+            v = ggml_cont_4d(ctx, ggml_transpose(ctx, v), dctx->current_position + 1, model->head_size, model->decoder_attn_heads, 2); 
+
+            // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
+            Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size, model->decoder_attn_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
+            struct ggml_tensor * q = ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
+            struct ggml_tensor * kq = ggml_mul_mat(ctx, ggml_cont(ctx, k), q);
+
+            // given that attention bias, scaling and masking are not used for decoding, it might be faster to prefer the #ggml_soft_max op here,
+            kq = ggml_soft_max_ext(ctx, kq, nullptr, 1.0f, 0.0f);
+            struct ggml_tensor * kqv = ggml_mul_mat(ctx, kq, v);
+            struct ggml_tensor * kqv_merged = ggml_cont(ctx, ggml_permute(ctx, kqv, 2, 0, 1, 3));
+            cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size, batch.sequence_length, 2);
+            cur = ggml_mul_mat(ctx, layer->self_attn_o, cur);
+        }
+
+
+        // if we ever need to support multiple step decoder runs then this reshape will need to be replaced with permutation.
+        cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
+        cur = ggml_add(ctx, cur, residual);
+        struct ggml_tensor * residual_cross = cur;
+
+        cur = dia_layer_norm(ctx, cur, layer->cross_attn_norm);
+        // cross-attention
+        {
+            struct ggml_tensor * cross_Qcur = ggml_mul_mat(ctx, layer->cross_attn_q, cur);
+
+            // only load the cross attention kv store when performing the encoding step
+            if (batch.encoder_step) {
+                build_dia_cross_kv_store(ctx, dctx, model, cache, gf, encoder_hidden_states, l);
+            }
+
+            struct ggml_tensor * cross_k = 
+                ggml_view_4d(
+                        ctx, cache->cross_k_l[l], model->head_size, model->decoder_attn_heads, 2,
+                        model->max_encoder_context_length, model->head_size*ggml_element_size(cache->cross_k_l[l]), 
+                        model->head_size*model->decoder_attn_heads*ggml_element_size(cache->cross_k_l[l]), 
+                        model->head_size*model->decoder_attn_heads*2*ggml_element_size(cache->cross_k_l[l]),                 
+                        0);
+            // the double permute operation shouldn't be necessary here, but it seems that currently ggml permute only currently alows for a single
+            // axis pair to be transposed.
+            cross_k = ggml_cont(ctx, ggml_permute(ctx, ggml_permute(ctx, cross_k, 0, 1, 3, 2), 0, 2, 1, 3));
+
+            struct ggml_tensor * cross_v = 
+                ggml_cont(ctx, ggml_view_4d(
+                        ctx, cache->cross_v_l[l], model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2,
+                        model->max_encoder_context_length*ggml_element_size(cache->cross_v_l[l]), 
+                        model->head_size*model->max_encoder_context_length*ggml_element_size(cache->cross_v_l[l]), 
+                        model->head_size*model->max_encoder_context_length*model->decoder_attn_heads*ggml_element_size(cache->cross_v_l[l]),
+                        0));
+
+            // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
+            cross_Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, cross_Qcur, model->head_size, model->decoder_attn_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
+            struct ggml_tensor * cross_q = ggml_cont(ctx, ggml_permute(ctx, cross_Qcur, 0, 2, 1, 3));
+            struct ggml_tensor * cross_kq = ggml_mul_mat(ctx, cross_k, cross_q);
+
+            // given that attention bias, scaling and masking are not used for decoding, it might be faster to prefer the #ggml_soft_max op here,
+            cross_kq = ggml_soft_max_ext(ctx, cross_kq, nullptr, 1.0f, 0.0f);
+            struct ggml_tensor * cross_kqv = ggml_mul_mat(ctx, cross_kq, cross_v);
+            struct ggml_tensor * cross_kqv_merged = ggml_cont(ctx, ggml_permute(ctx, cross_kqv, 2, 0, 1, 3));
+            cur = ggml_cont_3d(ctx, cross_kqv_merged, model->decoder_hidden_size, batch.sequence_length, 2);
+            cur = ggml_mul_mat(ctx, layer->cross_attn_o, cur);
+        }
+
+
+        // if we ever need to support multiple step decoder runs then this reshape will need to be replaced with permutation.
+        cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
+        cur = ggml_add(ctx, cur, residual_cross);
+        struct ggml_tensor * residual_mlp = cur;
+
+        cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
+        // mlp
+        {
+            cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)), ggml_mul_mat(ctx, layer->up, cur));
+            cur = ggml_mul_mat(ctx, layer->out, cur);
+        }
+
+        cur = ggml_add(ctx, cur, residual_mlp);
+    }
+
+    cur = dia_layer_norm(ctx, cur, model->decoder->norm);
+    cur = build_dia_head_outputs(ctx, model, cur);
+    return cur;
+}
+
+void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch & batch) {
+    // Dia's tokenization process is unusual. Essentially Dia takes the byte value for each character and uses that as 
+    // a token array. Additionally, because Dia performs a cfg-scale adjustment before sampling tokens, it is necessary to 
+    // generate with a conditioned context (i.e. with the text) and an unconditioned context (i.e. without any text) so that
+    // proper adjustments can be perfored at each generation step. This means that we need to pad the end of our tokens to the 
+    // max context size for both the conditional and unconditional sequence.
+
+    // if the sentence isn't prepended by dialogue start tokens, [S1] or [S2], then append one.
+    sentence = strip(sentence);
+    std::string start = sentence.substr(0, 4);
+    if (start != "[S1]" && start != "[S2]") {
+        sentence = "[S1] " + sentence;
+    }
+
+    // [S1] and [S2] are special character sequences that are replaced with the special tokens 0x01 and 0x02 respectively.
+    std::string r1(1, 1);
+    std::string r2(1, 2);
+    while (sentence.find("[S1]") != std::string::npos) {
+        size_t pos = sentence.find("[S1]");
+        sentence.replace(pos, 4, r1);
+    }
+    while (sentence.find("[S2]") != std::string::npos) {
+        size_t pos = sentence.find("[S2]");
+        sentence.replace(pos, 4, r2);
+    }
+
+    if (sentence.size() > model->max_encoder_context_length) {
+        TTS_ABORT("Dia currently only supports a max of %d characters and received an input of %d characters.", model->max_encoder_context_length, sentence.size());
+    }
+    batch.tokens.reserve(model->max_encoder_context_length * 2);
+    for (auto character : sentence) {
+        batch.tokens.push_back((uint32_t) character);
+    }
+    batch.sentence_length = batch.tokens.size();
+
+    for (int i = (int) batch.tokens.size(); i < model->max_encoder_context_length * 2; i++) {
+        batch.tokens.push_back(0u);
+    }
+ }
+
+dia_ubatch dia_runner::batch_from_sentence(std::string sentence) {
+    // if we are generating a new batch from tokens then we need to run the encoder step;
+    struct dia_ubatch batch{ 1, true};
+    tokenize_sentence(sentence, batch);
+    batch.audio_tokens.reserve(model->n_output_heads);
+    for (int i = 0; i < model->n_output_heads; i++) {
+        batch.audio_tokens.push_back(model->bos_token_id);
+    }
+    return batch;
+}
+
+/*
+ * There are two unique features of Dia's model architecture:
+ * 1.  Dia cleans its output generation by adding the difference between its text based output (its conditional output) and its unconditional output
+ *     to the conditional ouput before sampling. This is why the batch is set to two throughout the graph.
+ *
+ * 2.  Dia's decoder attends across the entire encoded space including the pad buffer which receives a unique attention mask. This is why the 
+ *     encoder sequence is always max length.
+ */
+struct ggml_cgraph * dia_runner::build_dia_graph(dia_ubatch & batch) {
+    init_build();
+    struct ggml_cgraph * gf = ggml_new_graph_custom(ctx, 8192, false);
+    struct ggml_tensor * encoded_states = nullptr;
+
+    if (batch.encoder_step) {
+        encoded_states = build_dia_encoder(ctx, model, dctx, batch);
+        ggml_build_forward_expand(gf, encoded_states);
+    }
+
+    struct ggml_tensor * cur = build_dia_decoder(gf, ctx, model, dctx, kv_cross_self, batch, encoded_states);
+    ggml_set_name(cur, "decoder_output");
+    ggml_build_forward_expand(gf, cur);
+    free_build();
+    
+    return gf;
+}
+
+void dia_runner::configure_generation(generation_configuration * config) {
+    GGML_ASSERT(config->max_tokens == 0 || config->max_tokens > model->max_delay);
+    decode_sampler->temperature = config->temperature;
+    decode_sampler->repetition_penalty = config->repetition_penalty;
+    decode_sampler->do_sample = config->sample;
+    decode_sampler->top_k = config->top_k;
+    model->max_generation_size = config->max_tokens > model->max_delay ? config->max_tokens : model->max_generation_size;
+}
+
+void dia_runner::set_inputs(dia_ubatch & batch) {
+    if (batch.encoder_step) {
+        ggml_backend_tensor_set(dctx->inp_tokens, batch.tokens.data(), 0, batch.tokens.size()*ggml_element_size(dctx->inp_tokens));
+        int32_t * ep = (int32_t*) dctx->encode_positions->data;
+        float * mask = (float*) dctx->encode_attn_mask->data;
+        for (int i = 0; i < model->max_encoder_context_length; i++) {
+            ep[i] = (int32_t) i;
+            for (int ii = 0; ii < model->max_encoder_context_length; ii++) {
+                if (i < batch.sentence_length) {
+                    mask[i*model->max_encoder_context_length + ii] = ii < batch.sentence_length ? 0.0 : -INFINITY;
+                } else {
+                    mask[i*model->max_encoder_context_length + ii] = ii >= batch.sentence_length ? 0.0 : -INFINITY;
+                }
+            }
+        }
+    }
+    // The audio tokens need to be repeated in the input in order to support cfg-scaling. I.E we need duplicate inputs for conditional and unconditional logits.
+    ggml_backend_tensor_set(dctx->audio_inp_tokens, batch.audio_tokens.data(), 0, batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens));
+    ggml_backend_tensor_set(dctx->audio_inp_tokens, batch.audio_tokens.data(), batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens), batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens));
+    ((int32_t*) dctx->positions->data)[0] = dctx->current_position;
+}
+
+
+int dia_runner::decode(dia_ubatch & batch) {
+    if (batch.encoder_step) {
+        dctx->prompt_size = batch.sentence_length;
+        dctx->output_tokens.reserve(dctx->max_generation_size * model->n_output_heads);
+    }
+    ggml_backend_sched_reset(dctx->sched);
+        
+    const size_t logits_size = model->output_vocab_size * dctx->max_generation_size * model->n_output_heads;
+    const size_t prev_size = dctx->buf_output ? ggml_backend_buffer_get_size(dctx->buf_output) : 0;
+    const size_t new_size  = logits_size * sizeof(float);
+    
+    if (!dctx->buf_output || prev_size < new_size) {
+        if (dctx->buf_output) {
+            ggml_backend_buffer_free(dctx->buf_output);
+            dctx->buf_output = nullptr;
+            dctx->logits = nullptr;
+        }
+
+        dctx->buf_output = ggml_backend_buft_alloc_buffer(dctx->backend_cpu_buffer, new_size);
+    }
+    
+    dctx->logits = (float *) ggml_backend_buffer_get_base(dctx->buf_output);
+
+    ggml_cgraph * gf = build_dia_graph(batch);
+
+    // the output is always the last tensor in the graph
+    struct ggml_tensor * res = gf->nodes[gf->n_nodes - 1];
+    std::string resname = ggml_get_name(res);
+    ggml_backend_sched_alloc_graph(dctx->sched, gf);
+
+    set_inputs(batch);
+
+    ggml_backend_sched_graph_compute_async(dctx->sched, gf);
+
+    float * logits_out = dctx->logits + dctx->current_position * model->output_vocab_size * model->n_output_heads;
+    dctx->get_ggml_node_data(res, logits_out, model->output_vocab_size * model->n_output_heads * sizeof(float));
+
+    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
+    // overlap with device computation.
+    ggml_backend_sched_reset(dctx->sched);
+
+    return 0;
+}
+
+dia_ubatch dia_runner::build_worst_case_batch()  {
+    struct dia_ubatch batch{ 1, true };
+    batch.tokens.resize(model->max_encoder_context_length * 2);
+    batch.audio_tokens.resize(model->n_output_heads);
+    return batch;
+}
+
+void dia_runner::prepare_post_load() {
+    dac_runner->prepare_post_load();
+    dia_kv_cache_init(kv_cross_self, model, dctx);
+    auto batch = build_worst_case_batch();
+    batch.sentence_length = model->max_encoder_context_length;
+    dctx->prompt_size = model->max_encoder_context_length;
+    auto gf = build_dia_graph(batch);
+    dctx->prep_schedule(gf);
+}
+
+bool dia_runner::check_stopping(dia_ubatch & batch) {
+    if (dctx->delay_steps == -1 && (batch.audio_tokens[0] == model->eos_token_id || dctx->current_position >= dctx->max_generation_size - model->max_delay)) {
+        dctx->delay_steps = model->max_delay;
+    }
+    
+    if (dctx->delay_steps > 0) {
+        int step_after_eos = model->max_delay - dctx->delay_steps;
+        for (int i = 0; i < model->delay_pattern.size(); i++) {
+            if (step_after_eos == model->delay_pattern[i]) {
+                batch.audio_tokens[i] = model->eos_token_id;
+            } else if (step_after_eos > model->delay_pattern[i]) {
+                batch.audio_tokens[i] = model->pad_token_id;
+            }
+        }
+        dctx->delay_steps -= 1;
+    }
+    return dctx->delay_steps == 0;
+}
+
+void dia_runner::adjust_output_tokens(std::vector<uint32_t> & output_tokens, std::vector<uint32_t> & filtered) {
+    // currently this is applying sliding window over the heads and filtering out bad tokens.
+    // If we convert the DAC model's quantizer layers to support by row + column embeddings then we will need to transpose
+    // the heads and the sequence here, but right now simplying using a strided view is more peformant.
+    size_t size = output_tokens.size();
+    filtered.reserve(size);
+    for (int i = 0; i < (size / model->n_output_heads) - model->max_delay; i++) {
+        for (int ii = 0; ii < model->n_output_heads; ii++) {
+            int next_index = i*model->n_output_heads+model->delay_pattern[ii]*model->n_output_heads+ii;
+            if (next_index > size) {
+                filtered.push_back(model->eos_token_id);
+            } else {
+                filtered.push_back(output_tokens[next_index]);
+            }
+        }
+    }
+}
+
+int dia_runner::generate_from_batch(dia_ubatch & batch, struct tts_response * output) {
+    while (!check_stopping(batch)) {
+        int state = decode(batch);
+        if (state != 0) {
+            return state;
+        }
+        decode_sampler->sample(dctx->logits + dctx->current_position * model->n_output_heads * model->output_vocab_size, dctx->output_tokens);
+        dctx->current_position += batch.sequence_length;
+        batch = dia_ubatch{ 1 };
+        uint32_t * last_outputs = (dctx->output_tokens.data() + (int) dctx->output_tokens.size() - model->n_output_heads);
+        batch.audio_tokens.reserve(model->n_output_heads);
+        for (int i = 0; i < model->n_output_heads; i++) {
+            batch.audio_tokens.push_back(dctx->current_position > i ? last_outputs[i] : model->bos_token_id);
+        }
+    }
+
+    std::vector<uint32_t> filtered_output_tokens;
+    adjust_output_tokens(dctx->output_tokens, filtered_output_tokens);
+    dac_runner->run(filtered_output_tokens.data(), (int32_t) filtered_output_tokens.size() / model->n_output_heads, output);
+    return 0;
+}
+
+int dia_runner::generate(std::string sentence, struct tts_response * output) {
+    dia_ubatch batch = batch_from_sentence(sentence);
+    dctx->reset();
+    decode_sampler->reset();
+    dctx->current_position = 0;
+    if (!kv_cross_self) {
+        kv_cross_self = new dia_kv_cache;
+        if (!dia_kv_cache_init(kv_cross_self, model, dctx)) {
+            return 1;
+        }
+    }
+    return generate_from_batch(batch, output);
+}
+
+void dia_runner::assign_weight(std::string name, ggml_tensor * tensor) {
+    if (tensor->data == NULL) {
+        return;
+    }
+
+    if (name.size() == 0) {
+        // handles the top level meta tensor
+        return;
+    }
+
+    if (name.size() > 14 && name.substr(0, 14) == "audio_encoder.") {
+        dac_runner->model->assign_weight(name.substr(14), tensor);
+    } else {
+        model->assign_weight(name, tensor);
+    }   
+}

--- a/src/dia_model.cpp
+++ b/src/dia_model.cpp
@@ -255,7 +255,6 @@ void dia_context::reset() {
     prompt_size = 0;
     output_tokens.clear();
     delay_steps = -1;
-    max_generation_size = model->max_generation_size;
 }
 
 struct dia_context * build_new_dia_context(struct dia_model * model, int n_threads, bool use_cpu) {
@@ -650,6 +649,9 @@ void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch & batch) {
     if (start != "[S1]" && start != "[S2]") {
         sentence = "[S1] " + sentence;
     }
+    if (sentence[sentence.size() - 1] != '.') {
+        sentence += ".";
+    }
 
     // [S1] and [S2] are special character sequences that are replaced with the special tokens 0x01 and 0x02 respectively.
     std::string r1(1, 1);
@@ -671,6 +673,9 @@ void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch & batch) {
         batch.tokens.push_back((uint32_t) character);
     }
     batch.sentence_length = batch.tokens.size();
+    if (batch.sentence_length <= model->max_delay) {
+        fprintf(stdout, "Your prompt has fewer than 16 tokens. Please note that Dia's generation with prompts that are fewer than 16 tokens is highly inconsistent.");
+    }
 
     for (int i = (int) batch.tokens.size(); i < model->max_encoder_context_length * 2; i++) {
         batch.tokens.push_back(0u);

--- a/src/dia_model.cpp
+++ b/src/dia_model.cpp
@@ -673,8 +673,9 @@ void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch & batch) {
         batch.tokens.push_back((uint32_t) character);
     }
     batch.sentence_length = batch.tokens.size();
-    if (batch.sentence_length <= model->max_delay) {
-        fprintf(stdout, "Your prompt has fewer than 16 tokens. Please note that Dia's generation with prompts that are fewer than 16 tokens is highly inconsistent.");
+    // this 100 token warning is arbitrarily chosen based on spot checking small prompt performance
+    if (batch.sentence_length <= 100) {
+        fprintf(stdout, "Your prompt has fewer than 100 tokens. Please note that Dia's generation with prompts that are fewer than 100 tokens is highly inconsistent.\n");
     }
 
     for (int i = (int) batch.tokens.size(); i < model->max_encoder_context_length * 2; i++) {

--- a/src/dia_model.h
+++ b/src/dia_model.h
@@ -70,7 +70,7 @@ struct dia_model : tts_model {
     uint32_t max_encoder_context_length = 1024;
 
 
-    float cfg_scale = 3.0;
+    float cfg_scale_data[2] = {3.0, 1024.0};
     uint32_t max_delay = 15;
     std::vector<uint32_t> delay_pattern = {0, 8, 9, 10, 11, 12, 13, 14, 15};
 

--- a/src/dia_model.h
+++ b/src/dia_model.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include "dac_model.h"
+#include "sampler.h"
+
+struct dia_encoder_layer {
+    struct ggml_tensor * k;
+    struct ggml_tensor * q;
+    struct ggml_tensor * v;
+    struct ggml_tensor * o;
+    struct ggml_tensor * self_attn_norm;
+
+    struct ggml_tensor * gate;
+    struct ggml_tensor * up;
+    struct ggml_tensor * out;
+    struct ggml_tensor * mlp_norm;
+};
+
+struct dia_decoder_layer {
+    struct ggml_tensor * self_attn_k;
+    struct ggml_tensor * self_attn_q;
+    struct ggml_tensor * self_attn_v;
+    struct ggml_tensor * self_attn_o;
+    struct ggml_tensor * self_attn_norm;
+    
+    struct ggml_tensor * cross_attn_k;
+    struct ggml_tensor * cross_attn_q;
+    struct ggml_tensor * cross_attn_v;
+    struct ggml_tensor * cross_attn_o;
+    struct ggml_tensor * cross_attn_norm;
+
+    struct ggml_tensor * gate;
+    struct ggml_tensor * up;
+    struct ggml_tensor * out;
+    struct ggml_tensor * mlp_norm;
+
+    struct ggml_tensor * pad_attn_values;
+};
+
+struct dia_encoder {
+    struct ggml_tensor * norm;
+    struct ggml_tensor * embedding;
+    std::vector<dia_encoder_layer*> layers;
+};
+
+struct dia_decoder {
+    struct ggml_tensor * norm;
+    std::vector<struct ggml_tensor*> embds;
+    std::vector<struct ggml_tensor*> heads;
+    std::vector<dia_decoder_layer*> layers;
+};
+
+struct dia_model : tts_model {
+    // These default configurations are based on the default configuration for the Dia 1.68b param model.
+    uint32_t n_output_heads = 9;
+    uint32_t n_encoder_layers = 12;
+    uint32_t n_decoder_layers = 18;
+    uint32_t encoder_hidden_size = 1024;
+    uint32_t decoder_hidden_size = 2048;
+    uint32_t encoder_attn_heads = 16;
+    uint32_t decoder_attn_heads = 16;
+    uint32_t decoder_query_heads = 4;
+    uint32_t head_size = 128;
+    uint32_t eos_token_id = 1024;
+    uint32_t pad_token_id = 1025;
+    uint32_t bos_token_id = 1026;
+    uint32_t output_vocab_size = 1028;
+    uint32_t audio_vocab_size = 1024;
+    uint32_t max_generation_size = 3072;
+    uint32_t max_encoder_context_length = 1024;
+
+
+    float cfg_scale = 3.0;
+    uint32_t max_delay = 15;
+    std::vector<uint32_t> delay_pattern = {0, 8, 9, 10, 11, 12, 13, 14, 15};
+
+    dia_encoder * encoder;
+    dia_decoder * decoder;
+    
+    void assign_weight(std::string name, ggml_tensor * tensor);
+    void assign_to_encoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name);
+    void assign_to_decoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name);
+    void assign_to_encoder_layer(std::string part, dia_encoder_layer * layer, struct ggml_tensor * tensor);
+    void assign_to_decoder_layer(std::string part, dia_decoder_layer * layer, struct ggml_tensor * tensor);
+    void prep_constants(gguf_context * meta);
+    void prep_layers();
+    void setup_from_file(gguf_context * meta_ctx, ggml_context * load_context, bool cpu_only) {
+        prep_constants(meta_ctx);
+        prep_layers();
+        tts_model::setup_from_file(meta_ctx, load_context, cpu_only, "dia", 1.30);
+    }
+};
+
+struct dia_context : runner_context {
+    dia_context(dia_model * model, int n_threads): runner_context(n_threads), model(model) {
+        max_generation_size = model->max_generation_size;
+    };
+
+    uint32_t current_position = 0;  // current position in the active sequence
+    int delay_steps           = -1; // the max remaining steps to take before terminating; is set after an eos token is seen on the first output channel
+    size_t prompt_size        = 0;
+    float * logits            = nullptr;
+
+    uint32_t max_generation_size; // this is set by the generation context or defaults to the config set on dia model.
+
+    std::vector<uint32_t> output_tokens;
+    struct dia_model * model;    
+    
+    struct ggml_tensor * inp_tokens;
+    struct ggml_tensor * audio_inp_tokens;
+    struct ggml_tensor * positions;
+    struct ggml_tensor * encode_positions;
+    struct ggml_tensor * encode_attn_mask;
+    struct ggml_tensor * cross_attn_mask;
+    
+    void build_schedule() {
+        runner_context::build_schedule(model->max_nodes());
+    }
+    void reset();
+};
+
+struct dia_kv_cache {
+    ggml_type tensor_type = GGML_TYPE_F32;
+
+    std::vector<struct ggml_tensor *> cross_k_l;
+    std::vector<struct ggml_tensor *> cross_v_l;
+
+    std::vector<struct ggml_tensor *> k_l;
+    std::vector<struct ggml_tensor *> v_l;
+    
+    struct ggml_context * ctx;
+    ggml_backend_buffer_type_t buft;
+    ggml_backend_buffer_t buf;
+    
+    void free() {
+        ggml_free(ctx);
+        ggml_backend_buffer_free(buf);
+    }
+
+    ~dia_kv_cache() {
+        free();
+    }
+};
+
+struct dia_ubatch {
+    dia_ubatch(size_t sequence_length, bool encoder_step = false): sequence_length(sequence_length), encoder_step(encoder_step) {};
+    bool encoder_step; // whether we are performing the prompt encoding in this step.
+    size_t sequence_length; // for just audio tokens the sequence length should be the total_tokens / num_heads; for normal generation this should always be 1.
+    size_t sentence_length; // the number of non padded tokens in the conditional context
+    std::vector<uint32_t> tokens; // character tokens for the encoder
+    std::vector<uint32_t> audio_tokens; // audio tokens from the last generation
+};
+
+struct dia_context * build_new_dia_context(struct dia_model * model, int n_threads, bool use_cpu = true);
+static bool dia_kv_cache_init(struct dia_kv_cache * cache, dia_model * model, dia_context * dctx) ;
+static struct ggml_tensor * build_dia_decoder_inp_embd(struct ggml_context * ctx, dia_context *dctx, dia_decoder * decoder, dia_ubatch & batch, uint32_t n_output_heads);
+static struct ggml_tensor * dia_layer_norm(struct ggml_context * ctx, struct ggml_tensor * inputs, struct ggml_tensor * weight);
+static struct ggml_tensor * build_dia_encoder_attn_mask(ggml_context * ctx, struct dia_context * dctx, dia_model * model);
+static struct ggml_tensor * build_dia_decoder_attn_mask(ggml_context * ctx, struct dia_context * dctx, dia_ubatch & batch);
+static struct ggml_tensor * build_dia_decoder_cross_attn_mask(ggml_context * ctx, struct dia_context * dctx, dia_ubatch & batch);
+static struct ggml_tensor * build_dia_head_outputs(struct ggml_context * ctx, dia_model * model, struct ggml_tensor * cur);
+static struct ggml_tensor * build_dia_encoder(ggml_context * ctx, dia_model * model, dia_context * dctx, dia_ubatch & batch);
+static void build_dia_self_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * k, struct ggml_tensor * v, dia_ubatch & batch, int layer_index);
+static void build_dia_cross_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * encoder_hidden_states, int layer_index);
+static struct ggml_tensor * build_dia_decoder( ggml_cgraph * gf, ggml_context * ctx, dia_model * model,  dia_context * dctx,  dia_kv_cache * cache, dia_ubatch & batch, struct ggml_tensor * encoder_hidden_states);
+
+// This struct is intended to support end-to-end TTS generation for the Dia model. As such, it manages Dia's model compilation, compute, generation,
+// tokenizationm and sampling process, and uses the dac_runner struct to encode audio outputs.
+struct dia_runner : tts_runner {
+    dia_runner(dia_model * model, dac_runner * audio_decoder, dia_context * dctx, sampler * samp, dia_kv_cache * cache): model(model), dac_runner(audio_decoder), dctx(dctx), decode_sampler(samp), kv_cross_self(cache) {
+        decode_sampler->vocab_size = model->output_vocab_size;
+    };
+    ~dia_runner() {
+        if (ctx) {
+            ggml_free(ctx);
+        }
+        model->free();
+        delete model;
+        delete kv_cross_self;
+        delete dac_runner;
+        delete dctx;
+        delete decode_sampler;
+    }
+    struct dia_model * model;
+    struct dac_runner * dac_runner;
+    struct dia_context * dctx;
+    struct dia_kv_cache * kv_cross_self = nullptr;
+    struct sampler * decode_sampler;
+
+    void init_build() {
+        tts_runner::init_build(&dctx->buf_compute_meta);
+    }
+
+    void tokenize_sentence(std::string sentence, dia_ubatch & tokens);
+    dia_ubatch batch_from_sentence(std::string sentence);
+    void configure_generation(generation_configuration * config);
+    void assign_weight(std::string name, ggml_tensor * tensor);
+    dia_ubatch build_worst_case_batch();
+    struct ggml_cgraph * build_dia_graph(dia_ubatch & batch);
+    void set_inputs(dia_ubatch & batch);
+    int decode(dia_ubatch & batch);
+    void prepare_post_load();
+    int generate(std::string sentence, struct tts_response * response);
+    bool check_stopping(dia_ubatch & batch);
+    void adjust_output_tokens(std::vector<uint32_t> & output_tokens, std::vector<uint32_t> & filtered);
+    int generate_from_batch(dia_ubatch & batch, struct tts_response * output);
+};

--- a/src/phonemizer.cpp
+++ b/src/phonemizer.cpp
@@ -11,16 +11,6 @@ const std::unordered_set<std::string> inline_combine_sets(const std::vector<std:
 	return combined;
 }
 
-std::string strip(std::string target, std::string vals) {
-	target.erase(target.begin(), std::find_if(target.begin(), target.end(), [&vals](unsigned char ch) {
-        return vals.find(ch) == std::string::npos;
-    }));
-    target.erase(std::find_if(target.rbegin(), target.rend(), [&vals](unsigned char ch) {
-        return vals.find(ch) == std::string::npos;
-    }).base(), target.end());
-    return target;
-}
-
 std::string replace(std::string target, char to_replace, char replacement) {
 	for (int i = 0; i < target.size(); i++) {
 		if (target[i] == to_replace) {
@@ -81,50 +71,6 @@ std::string replace_accents(std::string word) {
 		i += grab;
 	}
 	return new_word;
-}
-
-std::vector<std::string> split(std::string target, std::string split_on, bool include_split_characters) {
-	std::vector<std::string> output;
-    size_t last = 0;
-
-    for (int i = 0; i < target.size(); i++) {
-    	if (i > last && split_on.find(target[i]) != std::string::npos) {
-    		std::string part(target.substr(last, i - last));
-    		output.push_back(part);
-    		if (include_split_characters) {
-    			output.push_back(target.substr(i, 1));
-    		}
-    		last = i+1;
-    	}
-    }
-    if (last < target.size()) {
-    	std::string part(target.substr(last));
-    	output.push_back(part);
-    }
-
-    return output;
-}
-
-std::vector<std::string> split(std::string target, const char split_on, bool include_split_characters) {
-	std::vector<std::string> output;
-    size_t last = 0;
-
-    for (int i = 0; i < target.size(); i++) {
-    	if (i > last && split_on == target[i]) {
-    		std::string part(target.substr(last, i - last));
-    		output.push_back(part);
-    		if (include_split_characters) {
-    			output.push_back(target.substr(i, 1));
-    		}
-    		last = i+1;
-    	}
-    }
-    if (last < target.size()) {
-    	std::string part(target.substr(last));
-    	output.push_back(part);
-    }
-
-    return output;
 }
 
 int upper_count(std::string word) {

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -1,6 +1,6 @@
 #include "sampler.h"
 
-void sampler::sample(float * logits, std::vector<uint32_t> & output_tokens) {
+void sampler::sample(float * logits, std::vector<uint32_t> & output_tokens) {\
     // assume that we are pointing to the start of the first token output;
     if (!do_sample) {
         return max(logits, output_tokens);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,6 @@
 #include "util.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <stdarg.h>
 #ifdef __APPLE__

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,7 @@
 #include "ggml-cpp.h"
 
 #define TTS_ABORT(...) tts_abort(__FILE__, __LINE__, __VA_ARGS__)
+#define TTS_ASSERT(x) if (!(x)) TTS_ABORT("TTS_ASSERT(%s) failed", #x)
 
 struct model_tensor_meta {
 	uint32_t n_tensors = 0;
@@ -43,12 +44,18 @@ void compute_window_squared_sum(size_t n_fft, size_t hop, size_t n_frames, float
 struct ggml_tensor * stft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided);
 struct ggml_tensor * istft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window_squared_sum, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided);
 
-// This is a custom ops for sine_generation in the kokoro model.
+// This is a custom op for sine_generation in the Kokoro model.
 void uv_noise_compute(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, const struct ggml_tensor * c, int ith, int nth, void * userdata);
+
+// This is a custom op for logit correction in the Dia model.
+void cfg_scale(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, int ith, int nth, void * userdata);
 
 bool has_suffix(std::string value, std::string suffix);
 bool has_prefix(std::string value, std::string prefix);
 
+std::vector<std::string> split(std::string target, std::string split_on, bool include_split_characters = false);
+std::vector<std::string> split(std::string target, const char split_on, bool include_split_characters = false);
+std::string strip(std::string target, std::string vals = " ");
 std::string replace_any(std::string target, std::string to_replace, std::string replacement);
 
 [[noreturn]] void tts_abort(const char * file, int line, const char * fmt, ...);


### PR DESCRIPTION
Adds the core functionality to support Dia discussed here: Closes: https://github.com/mmwillet/TTS.cpp/issues/28

Fixed existing issues on my flight this morning. As such, Dia support should be ready for review tonight. I'll upload a model to a new hugging face repo as soon as possible (if the airport wifi allows it).

Missing functionality:
* Top-p sampling is not currently supported in the sampler. This has almost no impact most of the time because the top-k nucleus is already set very relatively low by default in Dia at 35 and the top-p value is relatively high at 0.95.
* Continued voice generation is not yet supported and looks like it will be necessary to support consistent voices.

Performance Characteristics and Notes:

1. The model is slow and I couldn't recreate the real-time metrics reported by [the Dia repo](https://github.com/nari-labs/dia) in python without GPUs. There are a few general reasons for this slowness:

-   cfg scale correction requires a batch generation of 2 (which should respond well to increased thread count)
-   the lack of a decoder cross-attention mask and Dia's weird pad token attention mask means that the encoding step always has to be performed across the max context size (which significantly slows down the encoding step). I tested out a very simple fix for this that prefills the cross attention key and value buffers with a static tensor that mimics the pad token outputs (which are relatively static) and will iteratively add support for that.
-   Dia has Parler's stopping problem. The more testing that I have done with Dia in Python the more I find that its stopping is extremely inconsistent (despite my original finding). VAD will almost certainly be needed and will result in with significant performance inconsistencies. 

2. The similarities between Parler and Dia will mean that quantization should be similarly achievable (as is other acceleration).

Thought on the current generation configuration pattern:

Dia has very different default generation configuration and this implies to me that we will likely want to couple generation configuration with each respective model. This will likely require a small refactor of the current argument configuration pattern such that when otherwise not specified each model's respective runner decides on its default generation configuration.

Important note here: _When testing out Dia, please use a temperature of 1.3 and a top-k of 35._