### PR TITLE
adds basic quantization support for Dia

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In this endeavor, MacOS and metal support will be treated as the primary platfor
 | [Parler TTS Mini](https://huggingface.co/parler-tts/parler-tts-mini-v1)  |&check;|&check;|&check;|[here](https://huggingface.co/mmwillet2/Parler_TTS_GGUF)|
 | [Parler TTS Large](https://huggingface.co/parler-tts/parler-tts-large-v1)|&check;|&check;|&check;|[here](https://huggingface.co/mmwillet2/Parler_TTS_GGUF)|
 | [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M)                      |&check;|&cross;|&cross;|[here](https://huggingface.co/mmwillet2/Kokoro_GGUF)    |
-| [Dia](https://github.com/nari-labs/dia)                                  |&check;|&check;|&cross;|[here](https://huggingface.co/mmwillet2/Dia_GGUF)       |
+| [Dia](https://github.com/nari-labs/dia)                                  |&check;|&check;|&check;|[here](https://huggingface.co/mmwillet2/Dia_GGUF)       |
 
 Additional Model support will initially be added based on open source model performance in the [TTS model arena](https://huggingface.co/spaces/TTS-AGI/TTS-Arena) and the availability of said models' architectures and checkpoints.
 

--- a/examples/quantize/README.md
+++ b/examples/quantize/README.md
@@ -14,7 +14,7 @@ This script converts a 32bit floating point TTS.cpp GGUF model file to a quantiz
 **Please note** Quantization and lower precision conversion is currently only supported for Parler TTS models. 
 
 In order to get a detailed breakdown of the functionality currently available you can call the cli with the `--help` parameter. This will return a breakdown of all parameters:
-```commandline
+```bash
 ./quantize --help
 
 --quantized-type (-qt):
@@ -37,12 +37,13 @@ In order to get a detailed breakdown of the functionality currently available yo
 
 General usage should follow from these possible parameters. E.G. The following command will save a quantized version of the model using Q4_0 quantization to `/model/path/to/new/gguf_file_q.gguf`:
 
-```commandline
+```bash
 ./quantize --model-path /model/path/to/gguf_file.gguf --quantized-model-path /model/path/to/new/gguf_file_q.gguf --quantized-type 2 
 ```
 Valid types passed to `--quantized-type` are described by the `ggml_type` enum in GGML:
 
 ```cpp
+        GGML_TYPE_F16     = 1,
         GGML_TYPE_Q4_0    = 2,
         GGML_TYPE_Q4_1    = 3,
         // GGML_TYPE_Q4_2 = 4, support has been removed
@@ -66,7 +67,6 @@ Valid types passed to `--quantized-type` are described by the `ggml_type` enum i
         GGML_TYPE_IQ2_S   = 22,
         GGML_TYPE_IQ4_XS  = 23,
         GGML_TYPE_I8      = 24,
-        GGML_TYPE_BF16    = 30,
         GGML_TYPE_Q4_0_4_4 = 31,
         GGML_TYPE_Q4_0_4_8 = 32,
         GGML_TYPE_Q4_0_8_8 = 33,

--- a/examples/quantize/quantize.cpp
+++ b/examples/quantize/quantize.cpp
@@ -13,24 +13,24 @@ std::vector<ggml_type> valid_quantization_types = {
 };
 
 int main(int argc, const char ** argv) {
-	int default_quantization = 2;
-    int default_n_threads = std::min((int)std::thread::hardware_concurrency(), 1);
+	int default_quantization = (int) GGML_TYPE_Q4_0;
+    int default_n_threads = std::max((int)std::thread::hardware_concurrency(), 1);
     arg_list args;
     args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini v1 to quantize.", "-mp", true));
     args.add_argument(string_arg("--quantized-model-path", "(REQUIRED) The path to save the model in a quantized format.", "-qp", true));
-    args.add_argument(int_arg("--quantized-type", "The ggml enum of the quantized type to convert compatible model tensors to. For more information see readme. Defaults to Q4_0 quantizatio (2).", "-qt", true, &default_quantization));
-    args.add_argument(int_arg("--n-threads", "The number of cpu threads to run the quantization process with. Defaults to known hardware concurrency.", "-nt", false, &default_n_threads));
-    args.add_argument(bool_arg("--convert-dac-to-f16", "Whether to convert the DAC audio decoder model to a 16 bit float.", "-df"));
-    args.add_argument(bool_arg("--quantize-output-heads", "Whether to quantize the output heads. Defaults to false and is true when passed (does not accept a parameter).", "-qh"));
-    args.add_argument(bool_arg("--quantize-text-embedding", "Whether to quantize the input text embededings. Defaults to false and is true when passed (does not accept a parameter).", "-qe"));
-    args.add_argument(bool_arg("--quantize-cross-attn-kv", "Whether to quantize the cross attention keys and values. Defaults to false and is true when passed (does not accept a parameter).", "-qkv"));
+    args.add_argument(int_arg("--quantized-type", "(OPTIONAL) The ggml enum of the quantized type to convert compatible model tensors to. For more information see readme. Defaults to Q4_0 quantization (2).", "-qt", true, &default_quantization));
+    args.add_argument(int_arg("--n-threads", "(OPTIONAL) The number of cpu threads to run the quantization process with. Defaults to known hardware concurrency.", "-nt", false, &default_n_threads));
+    args.add_argument(bool_arg("--convert-dac-to-f16", "(OPTIONAL) Whether to convert the DAC audio decoder model to a 16 bit float.", "-df"));
+    args.add_argument(bool_arg("--quantize-output-heads", "(OPTIONAL) Whether to quantize the output heads. Defaults to false and is true when passed (does not accept a parameter).", "-qh"));
+    args.add_argument(bool_arg("--quantize-text-embedding", "(OPTIONAL) Whether to quantize the input text embededings (only applicable for Parler TTS). Defaults to false and is true when passed (does not accept a parameter).", "-qe"));
+    args.add_argument(bool_arg("--quantize-cross-attn-kv", "(OPTIONAL) Whether to quantize the cross attention keys and values (only applicable for Parler TTS). Defaults to false and is true when passed (does not accept a parameter).", "-qkv"));
     args.parse(argc, argv);
     if (args.for_help) {
         args.help();
         return 0;
     }
     args.validate();
-    enum ggml_type qtype =static_cast<ggml_type>(*args.get_int_param("--quantized-type"));
+    enum ggml_type qtype = static_cast<ggml_type>(*args.get_int_param("--quantized-type"));
     if (std::find(valid_quantization_types.begin(), valid_quantization_types.end(), qtype) == valid_quantization_types.end()) {
     	fprintf(stderr, "ERROR: %d is not a valid quantization type.\n", qtype);
         exit(1);

--- a/include/tts.h
+++ b/include/tts.h
@@ -15,10 +15,9 @@ int generate(tts_runner * runner, std::string sentence, struct tts_response * re
 void update_conditional_prompt(tts_runner * runner, const std::string file_path, const std::string prompt, bool cpu_only = true);
 
 struct quantization_params {
-    quantization_params(uint32_t n_threads, enum ggml_type quantize_type, void * imatrix = nullptr): n_threads(n_threads), quantize_type(quantize_type), imatrix(imatrix) {};
+    quantization_params(uint32_t n_threads, enum ggml_type quantize_type): n_threads(n_threads), quantize_type(quantize_type) {};
     uint32_t n_threads;
     enum ggml_type quantize_type; // quantization type
-    void * imatrix = nullptr; // pointer to importance matrix data
     bool quantize_output_heads = false;
     bool quantize_text_embeddings = false;
     bool quantize_cross_attn_kv = false;


### PR DESCRIPTION
Addresses one of the requirements for this: https://github.com/mmwillet/TTS.cpp/issues/54

Behavior changes
- allows Dia arch GGUF files to be quantized
- removes unused importance matrices