### PR TITLE
adds basic support for top-p sampling

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -17,12 +17,14 @@ In order to get a detailed breakdown the functionality currently available you c
     The temperature to use when generating outputs. Defaults to 1.0.
 --repetition-penalty (-r):
     The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.
+--top-p (tp):
+    (OPTIONAL) the sum of probabilities to sample over. Must be a value between 0.0 and 1.0. Defaults to 1.0.
 --n-threads (-nt):
     The number of cpu threads to run generation with. Defaults to hardware concurrency. If hardware concurrency cannot be determined then it defaults to 1.
 --topk (-tk):
     (OPTIONAL) When set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.
 --max-tokens (-mt):
-    (OPTIONAL) The max audio tokens to generate. Only applied to Dia generation. If set to zero as is its default then the default max generation size
+    (OPTIONAL) The max audio tokens or token batches to generate where each represents approximates 11 ms of audio. Only applied to Dia generation. If set to zero as is its default then the default max generation size. Warning values under 15 are not supported.
 --use-metal (-m):
     (OPTIONAL) Whether to use metal acceleration
 --no-cross-attn (-ca):
@@ -32,7 +34,7 @@ In order to get a detailed breakdown the functionality currently available you c
 --play:
     (OPTIONAL) Whether to play back the audio immediately instead of saving it to file.
 --model-path (-mp):
-    (REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.
+    (REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1, Dia, or Kokoro.
 --prompt (-p):
     (REQUIRED) The text prompt for which to generate audio in quotation markers.
 --save-path (-sp):

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -12,8 +12,9 @@ int main(int argc, const char ** argv) {
     int default_top_k = 50;
     int default_max_tokens = 0;
     float default_repetition_penalty = 1.0f;
+    float default_top_p = 1.0f;
     arg_list args;
-    args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.", "-mp", true));
+    args.add_argument(string_arg("--model-path", "(REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1, Dia, or Kokoro.", "-mp", true));
     args.add_argument(string_arg("--prompt", "(REQUIRED) The text prompt for which to generate audio in quotation markers.", "-p", true));
     args.add_argument(string_arg("--save-path", "(OPTIONAL) The path to save the audio output to in a .wav format. Defaults to TTS.cpp.wav", "-sp", false, "TTS.cpp.wav"));
     args.add_argument(float_arg("--temperature", "The temperature to use when generating outputs. Defaults to 1.0.", "-t", false, &default_temperature));
@@ -25,9 +26,10 @@ int main(int argc, const char ** argv) {
     args.add_argument(string_arg("--conditional-prompt", "(OPTIONAL) A distinct conditional prompt to use for generating. If none is provided the preencoded prompt is used. '--text-encoder-path' must be set to use conditional generation.", "-cp", false));
     args.add_argument(string_arg("--text-encoder-path", "(OPTIONAL) The local path of the text encoder gguf model for conditional generaiton.", "-tep", false));
     args.add_argument(string_arg("--voice", "(OPTIONAL) The voice to use to generate the audio. This is only used for models with voice packs.", "-v", false, "af_alloy"));
-    args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TSS). By default, no VAD is applied.", "-va"));
+    args.add_argument(bool_arg("--vad", "(OPTIONAL) whether to apply voice inactivity detection (VAD) and strip silence form the end of the output (particularly useful for Parler TTS). By default, no VAD is applied.", "-va"));
     args.add_argument(string_arg("--espeak-voice-id", "(OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice ( see MultiLanguage Configuration in the README for more info).", "-eid", false));
     args.add_argument(int_arg("--max-tokens", "(OPTIONAL) The max audio tokens or token batches to generate where each represents approximates 11 ms of audio. Only applied to Dia generation. If set to zero as is its default then the default max generation size. Warning values under 15 are not supported.", "-mt", false, &default_max_tokens));
+    args.add_argument(float_arg("--top-p", "(OPTIONAL) the sum of probabilities to sample over. Must be a value between 0.0 and 1.0. Defaults to 1.0.", "-tp", false, &default_top_p));
     register_play_tts_response_args(args);
     args.parse(argc, argv);
     if (args.for_help) {
@@ -43,6 +45,11 @@ int main(int argc, const char ** argv) {
         exit(1);
     }
 
+    if (*args.get_float_param("--top-p") > 1.0f || *args.get_float_param("--top-p") <= 0.0f) {
+        fprintf(stderr, "The '--top-p' value must be between 0.0 and 1.0. It was set to '%.6f'.\n", *args.get_float_param("--top-p"));
+        exit(1);
+    }
+
     generation_configuration * config = new generation_configuration(
         args.get_string_param("--voice"), 
         *args.get_int_param("--topk"), 
@@ -50,7 +57,8 @@ int main(int argc, const char ** argv) {
         *args.get_float_param("--repetition-penalty"), 
         !args.get_bool_param("--no-cross-attn"),
         args.get_string_param("--espeak-voice-id"),
-        *args.get_int_param("--max-tokens"));
+        *args.get_int_param("--max-tokens"),
+        *args.get_float_param("--top-p"));
 
     struct tts_runner * runner = runner_from_file(args.get_string_param("--model-path"), *args.get_int_param("--n-threads"), config, !args.get_bool_param("--use-metal"));
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -6,15 +6,17 @@ This script runs a simple restful HTTP server which supports an OpenAI like `/v1
 
 In order to get a detailed breakdown of the functionality currently available you can call the tts-server with the `--help` parameter. This will return a breakdown of all parameters:
 
-```commandline
+```bash
 ./build/bin/tts-server --help
 
 --temperature (-t):
-    (OPTIONAL) The temperature to use when generating outputs by default. Defaults to 1.0.
+    (OPTIONAL) The temperature to use when generating outputs. Defaults to 1.0.
 --repetition-penalty (-r):
-    The by channel repetition penalty to be applied to the sampled output of the model by default. defaults to 1.0.
+    The by channel repetition penalty to be applied the sampled output of the model. defaults to 1.0.
+--top-p (tp):
+    (OPTIONAL) the default sum of probabilities to sample over. Must be a value between 0.0 and 1.0. Defaults to 1.0.
 --topk (-tk):
-    (OPTIONAL) When set to an integer value greater than 0, generation uses nucleus sampling over topk nucleaus size by default. Defaults to 50.
+    (OPTIONAL) when set to an integer value greater than 0 generation uses nucleus sampling over topk nucleaus size. Defaults to 50.
 --n-threads (-nt):
     The number of cpu threads to run generation with. Defaults to hardware concurrency.
 --port (-p):
@@ -30,7 +32,7 @@ In order to get a detailed breakdown of the functionality currently available yo
 --no-cross-attn (-ca):
     (OPTIONAL) Whether to not include cross attention
 --model-path (-mp):
-    (REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1.
+    (REQUIRED) The local path of the gguf model file for Parler TTS mini or large v1, Dia, or Kokoro.
 --text-encoder-path (-tep):
     (OPTIONAL) The local path of the text encoder gguf model for conditional generaiton.
 --ssl-file-cert (-sfc):
@@ -42,14 +44,14 @@ In order to get a detailed breakdown of the functionality currently available yo
 --voice (-v):
     (OPTIONAL) the default voice to use when generating audio. Only used with applicable models.
 --espeak-voice-id (-eid):
-    (OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice (see MultiLanguage Configuration in the cli README for more info).
+    (OPTIONAL) The espeak voice id to use for phonemization. This should only be specified when the correct espeak voice cannot be inferred from the kokoro voice (see #MultiLanguage Configuration in the cli README for more info).
 ```
 
 Important configuration here includes `--n-parallelism` which describes how may models for asynchronous processing and `--model-path` which describes from where to load the model locally.
 
 Simple local usage can be achieved via the following simple command:
 
-```commandline
+```bash
 ./build/bin/tts-server --model-path /path/to/model/gguf-file.gguf
 ```
 
@@ -66,7 +68,7 @@ The server currently supports three paths:
 
 The primary endpoint, `/v1/audio/speech`, can be interacted with like so:
 
-```commandline
+```bash
 curl http://127.0.0.1:8080/v1/audio/speech  \
   -H "Content-Type: application/json" \
   -d '{

--- a/include/common.h
+++ b/include/common.h
@@ -35,11 +35,13 @@ struct generation_configuration {
     	bool use_cross_attn = true, 
     	std::string espeak_voice_id = "",
     	int max_tokens = 0,
-    	bool sample = true): top_k(top_k), temperature(temperature), repetition_penalty(repetition_penalty), use_cross_attn(use_cross_attn), sample(sample), voice(voice), espeak_voice_id(espeak_voice_id), max_tokens(max_tokens) {};
+    	float top_p = 1.0,
+    	bool sample = true): top_k(top_k), temperature(temperature), repetition_penalty(repetition_penalty), use_cross_attn(use_cross_attn), sample(sample), voice(voice), espeak_voice_id(espeak_voice_id), max_tokens(max_tokens), top_p(top_p) {};
 
     bool use_cross_attn;
     float temperature;
     float repetition_penalty;
+    float top_p;
     int top_k;
     int max_tokens;
     std::string voice = "";

--- a/src/dia_model.cpp
+++ b/src/dia_model.cpp
@@ -726,6 +726,7 @@ void dia_runner::configure_generation(generation_configuration * config) {
     decode_sampler->repetition_penalty = config->repetition_penalty;
     decode_sampler->do_sample = config->sample;
     decode_sampler->top_k = config->top_k;
+    decode_sampler->top_p = config->top_p;
     dctx->max_generation_size = config->max_tokens > model->max_delay ? config->max_tokens : model->max_generation_size;
 }
 

--- a/src/parler_model.cpp
+++ b/src/parler_model.cpp
@@ -625,6 +625,7 @@ void parler_tts_runner::configure_generation(generation_configuration * config) 
     sampler->repetition_penalty = config->repetition_penalty;
     sampler->do_sample = config->sample;
     sampler->top_k = config->top_k;
+    sampler->top_p = config->top_p;
     model->use_cross_attn = config->use_cross_attn;
 }
 

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -7,10 +7,7 @@
 #include <numeric>
 #include <algorithm>
 
-// currently this is only built to support single sequence output sampling without
-// clustering, or beam search. While use of temperature is functional the repetition penalty is implemented
-// only for single sequence rather than channel sequences (which means that it is rarely applicable
-// for TTS generation.
+// currently this is only built to support single sequence output sampling without beam search.
 struct sampler {
     // These default configurations are based on the generation configuration for Parler TTS Mini (version 1.0)
     uint32_t n_output_heads = 9;
@@ -18,6 +15,7 @@ struct sampler {
     uint32_t vocab_size = 1088;
     float temperature = 1.0f;
     uint32_t top_k = 0;
+    float top_p = 1.0f;
     float repetition_penalty = 1.0f;
     std::vector<int32_t> last_token_ids;
     std::vector<uint32_t> repetition_counts;
@@ -27,7 +25,8 @@ struct sampler {
     void sample(float * logits, std::vector<uint32_t> & output_tokens);
     void softmax(float * logits, std::vector<std::vector<size_t>> picks, std::vector<uint32_t> max_indices);
     void max(float * logits, std::vector<uint32_t> & output_tokens);
-    std::vector<std::vector<size_t>> topk(float* logits);
+    std::vector<std::vector<size_t>> topk(float * logits, bool performed_softmax);
+    void topp(float * logits, std::vector<std::vector<size_t>> & picks, std::vector<float> & max_head_probs);
     void reset();
 };
 


### PR DESCRIPTION
Addresses https://github.com/mmwillet/TTS.cpp/issues/56

Top-p is essentially just a cumulative probability threshold for nucleus determination during sampling, but it has interactions with top-k sampling that we need to be careful about addressing. Core behavior changes are expressed in `sampler.cpp`. I will test this thoroughly tonight.