### PR TITLE
feat: migrate to ggml main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = ggml
 	url = https://github.com/mmwillet/ggml.git
 	branch = support-for-tts
+[submodule "llama.cpp"]
+	path = llama.cpp
+	url = https://github.com/ggml-org/llama.cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "ggml"]
-	path = ggml
-	url = https://github.com/mmwillet/ggml.git
-	branch = support-for-tts
 [submodule "llama.cpp"]
 	path = llama.cpp
 	url = https://github.com/ggml-org/llama.cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "llama.cpp"]
-	path = llama.cpp
-	url = https://github.com/ggml-org/llama.cpp.git
+[submodule "ggml"]
+	path = ggml
+	url = https://github.com/ggml-org/ggml.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 cmake_minimum_required(VERSION 3.14)
 project("tts.cpp" C CXX)
 include(CheckIncludeFileCXX)
@@ -76,14 +75,17 @@ option(TTS_BUILD_EXAMPLES "TTS.cpp: build examples" ON)
 # Required for relocatable CMake package
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/build-info.cmake)
 
-# override ggml options
+# override ggml options for llama.cpp
 set(GGML_ALL_WARNINGS       ${TTS_ALL_WARNINGS})
 set(GGML_FATAL_WARNINGS     ${TTS_FATAL_WARNINGS})
 
+# Increase GGML_MAX_NAME to support longer tensor names from TTS models
+add_compile_definitions(GGML_MAX_NAME=128)
 
-# build lib
+# build lib - Updated to use llama.cpp instead of mmwillet/ggml
 if (NOT TARGET ggml)
-    add_subdirectory(ggml)
+    # Add llama.cpp which provides the official GGML implementation
+    add_subdirectory(llama.cpp)
     # ... otherwise assume ggml is added by a parent CMakeLists.txt
 endif()
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,10 @@ set(GGML_FATAL_WARNINGS     ${TTS_FATAL_WARNINGS})
 # Increase GGML_MAX_NAME to support longer tensor names from TTS models
 add_compile_definitions(GGML_MAX_NAME=128)
 
-# build lib - Updated to use llama.cpp instead of mmwillet/ggml
+# build lib - Updated to use standalone ggml-org/ggml instead of llama.cpp bundled version
 if (NOT TARGET ggml)
-    # Add llama.cpp which provides the official GGML implementation
-    add_subdirectory(llama.cpp)
+    # Add standalone GGML which provides the latest GGML implementation
+    add_subdirectory(ggml)
     # ... otherwise assume ggml is added by a parent CMakeLists.txt
 endif()
 add_subdirectory(src)

--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -14,4 +14,4 @@ if (SDL2_FOUND)
     set_source_files_properties(playback.cpp PROPERTIES COMPILE_FLAGS -DSDL2_INSTALL=1)
 endif()
 
-target_link_libraries(cli PRIVATE ggml tts)
+target_link_libraries(cli PRIVATE tts)

--- a/examples/perf_battery/CMakeLists.txt
+++ b/examples/perf_battery/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(perf_battery perf_battery.cpp)
-target_link_libraries(perf_battery PRIVATE ggml tts)
+target_link_libraries(perf_battery PRIVATE tts)

--- a/examples/phonemize/CMakeLists.txt
+++ b/examples/phonemize/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(phonemize phonemize.cpp)
-target_link_libraries(phonemize PRIVATE ggml tts)
+target_link_libraries(phonemize PRIVATE tts)

--- a/examples/quantize/CMakeLists.txt
+++ b/examples/quantize/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(quantize quantize.cpp)
-target_link_libraries(quantize PRIVATE ggml tts)
+target_link_libraries(quantize PRIVATE tts)

--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(${TARGET} ${TARGET_SRCS})
 install(TARGETS ${TARGET} RUNTIME)
 
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(${TARGET} PRIVATE ggml tts)
+target_link_libraries(${TARGET} PRIVATE tts)
 
 
 if (LLAMA_SERVER_SSL)

--- a/include/tts.h
+++ b/include/tts.h
@@ -1,29 +1,45 @@
 #ifndef tts_h
 #define tts_h
 
-#include "parler_model.h"
-#include "kokoro_model.h"
 #include "dia_model.h"
-#include <thread>
+#include "kokoro_model.h"
+#include "parler_model.h"
+// Removed ggml-tts.h - using standard llama.cpp/ggml operations
 #include <fstream>
+#include <thread>
 
-struct tts_runner * parler_tts_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
-struct tts_runner * kokoro_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
-struct tts_runner * dia_from_file(gguf_context * meta_ctx, ggml_context * weight_ctx, int n_threads, generation_configuration * config, tts_arch arch, bool cpu_only);
-struct tts_runner * runner_from_file(const std::string & fname, int n_threads, generation_configuration * config, bool cpu_only = true);
-int generate(tts_runner * runner, std::string sentence, struct tts_response * response, generation_configuration * config);
-void update_conditional_prompt(tts_runner * runner, const std::string file_path, const std::string prompt, bool cpu_only = true);
+struct tts_runner *parler_tts_from_file(gguf_context *meta_ctx,
+                                        ggml_context *weight_ctx, int n_threads,
+                                        generation_configuration *config,
+                                        tts_arch arch, bool cpu_only);
+struct tts_runner *kokoro_from_file(gguf_context *meta_ctx,
+                                    ggml_context *weight_ctx, int n_threads,
+                                    generation_configuration *config,
+                                    tts_arch arch, bool cpu_only);
+struct tts_runner *dia_from_file(gguf_context *meta_ctx,
+                                 ggml_context *weight_ctx, int n_threads,
+                                 generation_configuration *config,
+                                 tts_arch arch, bool cpu_only);
+struct tts_runner *runner_from_file(const std::string &fname, int n_threads,
+                                    generation_configuration *config,
+                                    bool cpu_only = true);
+int generate(tts_runner *runner, std::string sentence,
+             struct tts_response *response, generation_configuration *config);
+void update_conditional_prompt(tts_runner *runner, const std::string file_path,
+                               const std::string prompt, bool cpu_only = true);
 
 struct quantization_params {
-    quantization_params(uint32_t n_threads, enum ggml_type quantize_type): n_threads(n_threads), quantize_type(quantize_type) {};
-    uint32_t n_threads;
-    enum ggml_type quantize_type; // quantization type
-    bool quantize_output_heads = false;
-    bool quantize_text_embeddings = false;
-    bool quantize_cross_attn_kv = false;
-    bool convert_dac_to_f16 = false;
+  quantization_params(uint32_t n_threads, enum ggml_type quantize_type)
+      : n_threads(n_threads), quantize_type(quantize_type){};
+  uint32_t n_threads;
+  enum ggml_type quantize_type; // quantization type
+  bool quantize_output_heads = false;
+  bool quantize_text_embeddings = false;
+  bool quantize_cross_attn_kv = false;
+  bool convert_dac_to_f16 = false;
 };
 
-void quantize_gguf(const std::string & ifile, const std::string & ofile, struct quantization_params * params);
+void quantize_gguf(const std::string &ifile, const std::string &ofile,
+                   struct quantization_params *params);
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ if (ESPEAK_INCLUDE_DIRS)
     set_source_files_properties(phonemizer.cpp PROPERTIES INCLUDE_DIRECTORIES "${ESPEAK_INCLUDE_DIRS}")
     target_link_libraries(tts PUBLIC ${ESPEAK_LIBRARIES})
 endif()
-target_link_libraries(tts PUBLIC ggml)
+target_link_libraries(tts PUBLIC llama)
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(tts PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ if (WIN32)
     endif()
 endif()
 
-# Using llama.cpp/ggml as the base GGML implementation
+# Using standalone ggml-org/ggml as the base GGML implementation
 
 # TTS
 
@@ -29,9 +29,9 @@ add_library(tts
             ggml-tts-ext.cpp
             )
 
-target_include_directories(tts PUBLIC . ../include ../llama.cpp/ggml/include/)
+target_include_directories(tts PUBLIC . ../include ../ggml/include/)
 
-# Using standard llama.cpp/ggml - no custom extensions needed
+# Using standalone ggml-org/ggml - with TTS extensions
 
 target_compile_features   (tts PUBLIC cxx_std_11) # don't bump
 
@@ -40,10 +40,10 @@ if (ESPEAK_INCLUDE_DIRS)
     set_source_files_properties(phonemizer.cpp PROPERTIES INCLUDE_DIRECTORIES "${ESPEAK_INCLUDE_DIRS}")
     target_link_libraries(tts PUBLIC ${ESPEAK_LIBRARIES})
 endif()
-target_link_libraries(tts PUBLIC llama)
+target_link_libraries(tts PUBLIC ggml)
 
 if (BUILD_SHARED_LIBS)
     set_target_properties(tts PROPERTIES POSITION_INDEPENDENT_CODE ON)
-    target_compile_definitions(tts PRIVATE LLAMA_BUILD)
-    target_compile_definitions(tts PUBLIC  LLAMA_SHARED)
+    target_compile_definitions(tts PRIVATE GGML_BUILD)
+    target_compile_definitions(tts PUBLIC  GGML_SHARED)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,8 @@ if (WIN32)
     endif()
 endif()
 
+# Using llama.cpp/ggml as the base GGML implementation
+
 # TTS
 
 add_library(tts
@@ -23,9 +25,13 @@ add_library(tts
             tts_model.cpp
             kokoro_model.cpp
             dia_model.cpp
+            ggml-tts-ext.h
+            ggml-tts-ext.cpp
             )
 
-target_include_directories(tts PUBLIC . ../include ../ggml/src/)
+target_include_directories(tts PUBLIC . ../include ../llama.cpp/ggml/include/)
+
+# Using standard llama.cpp/ggml - no custom extensions needed
 
 target_compile_features   (tts PUBLIC cxx_std_11) # don't bump
 

--- a/src/dac_model.cpp
+++ b/src/dac_model.cpp
@@ -1,6 +1,47 @@
 #include "dac_model.h"
+// Removed ggml-tts.h - using standard llama.cpp/ggml operations
+#include "util.h"
 #include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <map>
 #include <stdexcept>
+#include <string>
+#include <vector>
+
+// Helper function to properly handle bias tensor broadcasting
+// DAC models have 4D bias tensors [N, 1, 1, 1] that need to be broadcast to
+// match conv results
+static struct ggml_tensor *prepare_bias_for_add(struct ggml_context *ctx,
+                                                struct ggml_tensor *bias,
+                                                struct ggml_tensor *target) {
+  // For 1D convolution bias: reshape from [N, 1, 1, 1] to [1, N, 1, 1]
+  // so it broadcasts across the time dimension (dim 0) but matches channels
+  // (dim 1)
+  return ggml_reshape_4d(ctx, bias, 1, bias->ne[0], 1, 1);
+}
+
+// Helper function to handle quantized tensors for convolution operations
+// Convolution operations in GGML require F16 or F32 tensors, but quantized
+// models may have Q4/Q8 weights. This function dequantizes them to F16 when
+// needed.
+static struct ggml_tensor *prepare_conv_weight(struct ggml_context *ctx,
+                                               struct ggml_tensor *weight) {
+  // Check if the tensor needs conversion to F16 (for im2col compatibility)
+  if (weight->type != GGML_TYPE_F16) {
+    // Create a new F16 tensor with the same shape
+    struct ggml_tensor *converted =
+        ggml_new_tensor(ctx, GGML_TYPE_F16, ggml_n_dims(weight), weight->ne);
+    // Copy and convert the weight to F16
+    converted = ggml_cpy(ctx, weight, converted);
+    return converted;
+  }
+  // If already F16, return as-is
+  return weight;
+}
 
 // For loading DAC model from gguf file.
 static const std::map<std::string, dac_tensor> DAC_TENSOR_GGUF_LOOKUP = {
@@ -25,322 +66,394 @@ static const std::map<std::string, dac_tensor> DAC_TENSOR_GGUF_LOOKUP = {
     {".codebook.weight", DAC_QUANTIZER_LAYER_CODEBOOK},
 };
 
-void dac_model::prep_constants(gguf_context * meta) {
-    int output_heads_key = search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads", "output_heads", "dia.decoder.output_heads"});
-    if (output_heads_key != -1) {
-        n_heads = gguf_get_val_u32(meta, output_heads_key);;
-    }
+void dac_model::prep_constants(gguf_context *meta) {
+  int output_heads_key =
+      search_for_gguf_keys(meta, {"parler-tts.decoder.output_heads",
+                                  "output_heads", "dia.decoder.output_heads"});
+  if (output_heads_key != -1) {
+    n_heads = gguf_get_val_u32(meta, output_heads_key);
+    ;
+  }
 
-    int sampling_factor_key = search_for_gguf_keys(meta, {"dac.up_sampling_factor", "up_sampling_factor"});
-    if (sampling_factor_key != -1) {
-        up_sampling_factor = gguf_get_val_u32(meta, sampling_factor_key);
+  int sampling_factor_key = search_for_gguf_keys(
+      meta, {"dac.up_sampling_factor", "up_sampling_factor"});
+  if (sampling_factor_key != -1) {
+    up_sampling_factor = gguf_get_val_u32(meta, sampling_factor_key);
+  }
+
+  int max_gen_key = search_for_gguf_keys(
+      meta, {"parler-tts.decoder.max_generation", "max_generation",
+             "dia.decoder.max_generation"});
+  if (max_gen_key != -1) {
+    max_generation_size = gguf_get_val_u32(meta, max_gen_key);
+  }
+
+  for (int i = 0; i < (int)layers.size(); i++) {
+    std::string stride_kw = "dac_layer_stride_" + std::to_string(i);
+    std::string padding_kw = "dac_layer_padding_" + std::to_string(i);
+    int layer_stride_key =
+        search_for_gguf_keys(meta, {"dac." + stride_kw, stride_kw});
+    if (layer_stride_key == -1) {
+      TTS_ABORT("key %s must be specified in gguf file.",
+                ("dac." + stride_kw).c_str());
     }
-    
-    int max_gen_key = search_for_gguf_keys(meta, {"parler-tts.decoder.max_generation", "max_generation", "dia.decoder.max_generation"});
-    if (max_gen_key != -1) {
-        max_generation_size = gguf_get_val_u32(meta, max_gen_key);
+    layers[i].stride = gguf_get_val_u32(meta, layer_stride_key);
+    int layer_padding_key =
+        search_for_gguf_keys(meta, {"dac." + padding_kw, padding_kw});
+    if (layer_padding_key == -1) {
+      TTS_ABORT("key %s must be specified in gguf file.",
+                ("dac." + padding_kw).c_str());
     }
-    
-    for (int i = 0; i < (int) layers.size(); i++)  {
-        std::string stride_kw = "dac_layer_stride_" + std::to_string(i);
-        std::string padding_kw = "dac_layer_padding_" + std::to_string(i);
-        int layer_stride_key = search_for_gguf_keys(meta, {"dac." + stride_kw, stride_kw});
-        if (layer_stride_key == -1) {
-            TTS_ABORT("key %s must be specified in gguf file.", ("dac." + stride_kw).c_str());
-        }
-        layers[i].stride = gguf_get_val_u32(meta, layer_stride_key);
-        int layer_padding_key = search_for_gguf_keys(meta, {"dac." + padding_kw, padding_kw});
-        if (layer_padding_key == -1) {
-            TTS_ABORT("key %s must be specified in gguf file.", ("dac." + padding_kw).c_str());
-        }
-        layers[i].padding = gguf_get_val_u32(meta, layer_padding_key);
-    }
+    layers[i].padding = gguf_get_val_u32(meta, layer_padding_key);
+  }
 }
 
-void dac_model::prep_layers(gguf_context * meta) {
-    for (int i = 0; i < n_heads; i++) {
-        dac_quantize_layer l;
-        quantizer_layers.push_back(l);
+void dac_model::prep_layers(gguf_context *meta) {
+  for (int i = 0; i < n_heads; i++) {
+    dac_quantize_layer l;
+    quantizer_layers.push_back(l);
+  }
+
+  for (int i = 0; i < n_layers; i++) {
+    dac_layer l;
+    // all dac layers have 3 residual units
+    for (int ii = 0; ii < 3; ii++) {
+      dac_residual_unit u;
+      l.residual_blocks.push_back(u);
     }
-    
-    for (int i = 0; i < n_layers; i++) {
-        dac_layer l;
-        // all dac layers have 3 residual units
-        for (int ii = 0; ii < 3; ii++) {
-            dac_residual_unit u;
-            l.residual_blocks.push_back(u);
-        }
-        layers.push_back(l);
-    }
+    layers.push_back(l);
+  }
 }
 
-void dac_model::assign_weight(std::string name, ggml_tensor * tensor) {
-    assign_to_audio_encoder(this, name, tensor);
+void dac_model::assign_weight(std::string name, ggml_tensor *tensor) {
+  assign_to_audio_encoder(this, name, tensor);
 }
 
-void assign_residual_unit(dac_model * model, dac_residual_unit * l, std::string name, ggml_tensor * tensor) {
-    try {
-        dac_tensor tensor_type = DAC_TENSOR_GGUF_LOOKUP.at(name);
-        switch (tensor_type) {
-            case DAC_ENCODER_LAYER_RES_BLK_IN_SNAKE:
-                l->in_snake_alpha = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(l->in_snake_alpha, tensor);
-                break;
-            case DAC_ENCODER_LAYER_RES_BLK_OUT_SNAKE:
-                l->out_snake_alpha = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(l->out_snake_alpha, tensor);
-                break;
-            case DAC_ENCODER_LAYER_RES_BLK_IN_KERNEL:
-                l->in_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(l->in_conv_kernel, tensor);
-                break;
-            case DAC_ENCODER_LAYER_RES_BLK_OUT_KERNEL:
-                l->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(l->out_conv_kernel, tensor);
-                break;
-            case DAC_ENCODER_LAYER_RES_BLK_IN_BIAS:
-                l->in_conv_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(l->in_conv_bias, tensor);
-                break;
-            case DAC_ENCODER_LAYER_RES_BLK_OUT_BIAS:
-                l->out_conv_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(l->out_conv_bias, tensor);
-                break;
-            default:
-                fprintf(stdout, "residual unit unassigned tensor %s\n", name.c_str());
-                break;
-        }
-    } catch (const std::out_of_range& e) {
-        TTS_ABORT("Error: %s\nTensor, '%s', is not a valid tensor.", e.what(), name.c_str());
+void assign_residual_unit(dac_model *model, dac_residual_unit *l,
+                          std::string name, ggml_tensor *tensor) {
+  try {
+    dac_tensor tensor_type = DAC_TENSOR_GGUF_LOOKUP.at(name);
+    switch (tensor_type) {
+    case DAC_ENCODER_LAYER_RES_BLK_IN_SNAKE: {
+      l->in_snake_alpha = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->in_snake_alpha, tensor);
+      break;
     }
-
-}
-
-void assign_dac_layer(dac_model * model, dac_layer * layer, std::string name, ggml_tensor * tensor) {
-    if (DAC_TENSOR_GGUF_LOOKUP.find(name) != DAC_TENSOR_GGUF_LOOKUP.end()) {
-        switch(DAC_TENSOR_GGUF_LOOKUP.at(name)) {
-            case DAC_ENCODER_LAYER_SNAKE_ALPHA:
-                layer->snake_alpha_in = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(layer->snake_alpha_in, tensor);
-                break;
-            case DAC_ENCODER_LAYER_OUT_KERNEL:
-                layer->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(layer->out_conv_kernel, tensor);
-                break;
-            case DAC_ENCODER_LAYER_OUT_BIAS:
-                layer->out_conv_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(layer->out_conv_bias, tensor);
-                break;
-            default:
-                fprintf(stdout, "layer unassigned tensor %s\n", name.c_str());
-                break;
-        }
-    } else if (std::find_if(name.begin(), name.end(), ::isdigit) != name.end())  {
-        auto pair = parse_layer_count(name);
-        int l = pair.first;
-        std::string lt_name = pair.second;
-        assign_residual_unit(model, &layer->residual_blocks[l], lt_name, tensor);
+    case DAC_ENCODER_LAYER_RES_BLK_OUT_SNAKE: {
+      l->out_snake_alpha = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->out_snake_alpha, tensor);
+      break;
     }
-}
-
-void assign_quantizer_layer(dac_model * model, dac_quantize_layer * layer, std::string name, ggml_tensor * tensor) {
-    try {
-        switch(DAC_TENSOR_GGUF_LOOKUP.at(name)) {
-            case DAC_QUANTIZER_LAYER_OUT_KERNEL:
-                layer->out_proj_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(layer->out_proj_kernel, tensor);
-                break;
-            case DAC_QUANTIZER_LAYER_OUT_BIAS:
-                layer->out_proj_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(layer->out_proj_bias, tensor);
-                break;
-            case DAC_QUANTIZER_LAYER_CODEBOOK:
-                layer->codebook = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(layer->codebook, tensor);
-                break;
-            default:
-                fprintf(stdout, "quantized layer unassigned tensor %s\n", name.c_str());
-                break;
-        }
-    }  catch (const std::out_of_range& e) {
-        TTS_ABORT("Error: %s\nTensor, '%s', is not a valid tensor.", e.what(), name.c_str());
+    case DAC_ENCODER_LAYER_RES_BLK_IN_KERNEL:
+      l->in_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->in_conv_kernel, tensor);
+      break;
+    case DAC_ENCODER_LAYER_RES_BLK_OUT_KERNEL:
+      l->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->out_conv_kernel, tensor);
+      break;
+    case DAC_ENCODER_LAYER_RES_BLK_IN_BIAS: {
+      l->in_conv_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->in_conv_bias, tensor);
+      break;
     }
-}
-
-void assign_to_audio_encoder(dac_model * model, std::string name, ggml_tensor * tensor) {
-    if (DAC_TENSOR_GGUF_LOOKUP.find(name) != DAC_TENSOR_GGUF_LOOKUP.end()) {
-        switch(DAC_TENSOR_GGUF_LOOKUP.at(name)) {
-            case DAC_ENCODER_IN_BIAS:
-                model->in_conv_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(model->in_conv_bias, tensor);
-                break;
-            case DAC_ENCODER_IN_KERNEL:
-                model->in_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(model->in_conv_kernel, tensor);
-                break;
-            case DAC_ENCODER_OUT_BIAS:
-                model->out_conv_bias = ggml_dup_tensor(model->ctx, ggml_transpose(model->ctx, tensor));
-                model->set_tensor(model->out_conv_bias, tensor);
-                break;
-            case DAC_ENCODER_OUT_KERNEL:
-                model->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(model->out_conv_kernel, tensor);
-                break;
-            case DAC_ENCODER_SNAKE_ALPHA:
-                model->snake_alpha = ggml_dup_tensor(model->ctx, tensor);
-                model->set_tensor(model->snake_alpha, tensor);
-                break;
-            default:
-                fprintf(stdout, "unassigned tensor %s\n", name.c_str());
-                break;
-        }
-    } else if (std::find_if(name.begin(), name.end(), ::isdigit) != name.end())  {
-        auto pair = parse_layer_count(name);
-        int l = pair.first;
-        std::string lt_name = pair.second;
-        if (name.find("quantizers") != std::string::npos) {
-            assign_quantizer_layer(model, &model->quantizer_layers[l], lt_name, tensor);
-        } else {
-            assign_dac_layer(model, &model->layers[l - 1], lt_name, tensor);
-        }
+    case DAC_ENCODER_LAYER_RES_BLK_OUT_BIAS: {
+      l->out_conv_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(l->out_conv_bias, tensor);
+      break;
     }
-}
-
-static struct ggml_tensor * dac_build_audio_inputs(struct ggml_context * ctx, struct dac_context * dctx, const dac_ubatch & batch, std::vector<dac_quantize_layer> layers) {
-    struct ggml_tensor * embd;
-    
-    dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length*dctx->model->n_heads);
-    ggml_set_input(dctx->inp_tokens);
-
-    if (dctx->backend) {
-        ggml_backend_sched_set_tensor_backend(dctx->sched, dctx->inp_tokens, dctx->backend);
+    default:
+      TTS_ABORT("Unhandled tensor type in assign_residual_unit: %d\n",
+                tensor_type);
     }
+  } catch (const std::out_of_range &e) {
+    TTS_ABORT("Unknown tensor name in assign_residual_unit: %s\n",
+              name.c_str());
+  }
+}
 
-    for(int i = 0; i < dctx->model->n_heads; i++) {
-        auto quantize_layer = dctx->model->quantizer_layers[i];
-        struct ggml_tensor * code = ggml_cont(ctx, ggml_view_2d(ctx, dctx->inp_tokens, 1, batch.sequence_length, dctx->model->n_heads*ggml_type_size(GGML_TYPE_I32), i*ggml_type_size(GGML_TYPE_I32)));
-        code = ggml_reshape_1d(ctx, code, batch.sequence_length);
-        code = ggml_get_rows(ctx, quantize_layer.codebook, code);
-        code = ggml_cont(ctx, ggml_transpose(ctx, code));
-        code = ggml_conv_1d(ctx, quantize_layer.out_proj_kernel, code, 1, 0, 1);
-        code = ggml_add(ctx, code, quantize_layer.out_proj_bias);
-
-        if (i == 0) {
-            embd = code;
-        } else {
-            embd = ggml_add(ctx, embd, code);
-        }
+void assign_dac_layer(dac_model *model, dac_layer *layer, std::string name,
+                      ggml_tensor *tensor) {
+  if (DAC_TENSOR_GGUF_LOOKUP.find(name) != DAC_TENSOR_GGUF_LOOKUP.end()) {
+    switch (DAC_TENSOR_GGUF_LOOKUP.at(name)) {
+    case DAC_ENCODER_LAYER_SNAKE_ALPHA: {
+      layer->snake_alpha_in = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->snake_alpha_in, tensor);
+      break;
     }
-    return embd;
-}
-
-static struct ggml_tensor * build_residual_unit(ggml_context * ctx, struct ggml_tensor * cur, dac_residual_unit & u, int padding, int dilation) {
-    struct ggml_tensor * residual = cur;
-    cur = snake_1d(ctx, u.in_snake_alpha, cur);
-    cur = ggml_conv_1d(ctx, u.in_conv_kernel, cur, 1, padding, dilation);
-    cur = ggml_add(ctx, cur, u.in_conv_bias);
-    cur = snake_1d(ctx, u.out_snake_alpha, cur);
-    cur = ggml_conv_1d(ctx, u.out_conv_kernel,  cur, 1, 0, 1);
-    cur = ggml_add(ctx, cur, u.out_conv_bias);
-    return ggml_add(ctx, cur, residual);
-}
-
-static struct ggml_tensor * build_decoder_block(ggml_context * ctx, struct ggml_tensor * cur, dac_layer & l, struct dac_context * dctx) {
-    cur = snake_1d(ctx, l.snake_alpha_in, cur);
-    cur = ggml_conv_transpose_1d(ctx, l.out_conv_kernel, cur, l.stride, l.padding, 1, 0, 1);
-    cur = ggml_add(ctx, cur, l.out_conv_bias);
-    for (int i = 0; i < l.residual_blocks.size(); i++) {
-        cur = build_residual_unit(ctx, cur, l.residual_blocks[i], pow(3, (i + 1)), pow(3, i));
+    case DAC_ENCODER_LAYER_OUT_KERNEL:
+      layer->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->out_conv_kernel, tensor);
+      break;
+    case DAC_ENCODER_LAYER_OUT_BIAS: {
+      layer->out_conv_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->out_conv_bias, tensor);
+      break;
     }
-    return cur;
+    default:
+      fprintf(stdout, "layer unassigned tensor %s\n", name.c_str());
+      break;
+    }
+  } else if (std::find_if(name.begin(), name.end(), ::isdigit) != name.end()) {
+    auto pair = parse_layer_count(name);
+    int l = pair.first;
+    std::string lt_name = pair.second;
+    assign_residual_unit(model, &layer->residual_blocks[l], lt_name, tensor);
+  }
 }
 
-struct dac_context * build_new_dac_context(struct dac_model * model, int n_threads, bool use_cpu) {
-    dac_context * dctx = new dac_context(model, n_threads);
-    if (!use_cpu) {
+void assign_quantizer_layer(dac_model *model, dac_quantize_layer *layer,
+                            std::string name, ggml_tensor *tensor) {
+  try {
+    switch (DAC_TENSOR_GGUF_LOOKUP.at(name)) {
+    case DAC_QUANTIZER_LAYER_OUT_KERNEL:
+      layer->out_proj_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->out_proj_kernel, tensor);
+      break;
+    case DAC_QUANTIZER_LAYER_OUT_BIAS: {
+      layer->out_proj_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->out_proj_bias, tensor);
+      break;
+    }
+    case DAC_QUANTIZER_LAYER_CODEBOOK:
+      layer->codebook = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(layer->codebook, tensor);
+      break;
+    default:
+      fprintf(stdout, "quantized layer unassigned tensor %s\n", name.c_str());
+      break;
+    }
+  } catch (const std::out_of_range &e) {
+    TTS_ABORT("Error: %s\nTensor, '%s', is not a valid tensor.", e.what(),
+              name.c_str());
+  }
+}
+
+void assign_to_audio_encoder(dac_model *model, std::string name,
+                             ggml_tensor *tensor) {
+  if (DAC_TENSOR_GGUF_LOOKUP.find(name) != DAC_TENSOR_GGUF_LOOKUP.end()) {
+    switch (DAC_TENSOR_GGUF_LOOKUP.at(name)) {
+    case DAC_ENCODER_IN_BIAS: {
+      model->in_conv_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(model->in_conv_bias, tensor);
+      break;
+    }
+    case DAC_ENCODER_IN_KERNEL:
+      model->in_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(model->in_conv_kernel, tensor);
+      break;
+    case DAC_ENCODER_OUT_BIAS: {
+      model->out_conv_bias = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(model->out_conv_bias, tensor);
+      break;
+    }
+    case DAC_ENCODER_OUT_KERNEL:
+      model->out_conv_kernel = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(model->out_conv_kernel, tensor);
+      break;
+    case DAC_ENCODER_SNAKE_ALPHA: {
+      model->snake_alpha = ggml_dup_tensor(model->ctx, tensor);
+      model->set_tensor(model->snake_alpha, tensor);
+      break;
+    }
+    default:
+      fprintf(stdout, "unassigned tensor %s\n", name.c_str());
+      break;
+    }
+  } else if (std::find_if(name.begin(), name.end(), ::isdigit) != name.end()) {
+    auto pair = parse_layer_count(name);
+    int l = pair.first;
+    std::string lt_name = pair.second;
+    if (name.find("quantizers") != std::string::npos) {
+      assign_quantizer_layer(model, &model->quantizer_layers[l], lt_name,
+                             tensor);
+    } else {
+      assign_dac_layer(model, &model->layers[l - 1], lt_name, tensor);
+    }
+  }
+}
+
+static struct ggml_tensor *
+dac_build_audio_inputs(struct ggml_context *ctx, struct dac_context *dctx,
+                       const dac_ubatch &batch,
+                       std::vector<dac_quantize_layer> layers) {
+  struct ggml_tensor *embd;
+
+  dctx->inp_tokens = ggml_new_tensor_1d(
+      ctx, GGML_TYPE_I32, batch.sequence_length * dctx->model->n_heads);
+  ggml_set_input(dctx->inp_tokens);
+
+  if (dctx->backend) {
+    ggml_backend_sched_set_tensor_backend(dctx->sched, dctx->inp_tokens,
+                                          dctx->backend);
+  }
+
+  for (int i = 0; i < dctx->model->n_heads; i++) {
+    auto quantize_layer = dctx->model->quantizer_layers[i];
+    struct ggml_tensor *code = ggml_cont(
+        ctx, ggml_view_2d(ctx, dctx->inp_tokens, 1, batch.sequence_length,
+                          dctx->model->n_heads * ggml_type_size(GGML_TYPE_I32),
+                          i * ggml_type_size(GGML_TYPE_I32)));
+    code = ggml_reshape_1d(ctx, code, batch.sequence_length);
+    code = ggml_get_rows(ctx, quantize_layer.codebook, code);
+    code = ggml_cont(ctx, ggml_transpose(ctx, code));
+    struct ggml_tensor *prepared_kernel =
+        prepare_conv_weight(ctx, quantize_layer.out_proj_kernel);
+    code = ggml_conv_1d(ctx, prepared_kernel, code, 1, 0, 1);
+    struct ggml_tensor *prepared_bias =
+        prepare_bias_for_add(ctx, quantize_layer.out_proj_bias, code);
+    code = ggml_add(ctx, code, prepared_bias);
+
+    if (i == 0) {
+      embd = code;
+    } else {
+      embd = ggml_add(ctx, embd, code);
+    }
+  }
+  return embd;
+}
+
+static struct ggml_tensor *build_residual_unit(ggml_context *ctx,
+                                               struct ggml_tensor *cur,
+                                               dac_residual_unit &u,
+                                               int padding, int dilation) {
+  struct ggml_tensor *residual = cur;
+  cur = snake_1d(ctx, u.in_snake_alpha, cur);
+  struct ggml_tensor *prepared_in_kernel =
+      prepare_conv_weight(ctx, u.in_conv_kernel);
+  cur = ggml_conv_1d(ctx, prepared_in_kernel, cur, 1, padding, dilation);
+  struct ggml_tensor *prepared_bias1 =
+      prepare_bias_for_add(ctx, u.in_conv_bias, cur);
+  cur = ggml_add(ctx, cur, prepared_bias1);
+  cur = snake_1d(ctx, u.out_snake_alpha, cur);
+  struct ggml_tensor *prepared_out_kernel =
+      prepare_conv_weight(ctx, u.out_conv_kernel);
+  cur = ggml_conv_1d(ctx, prepared_out_kernel, cur, 1, 0, 1);
+  struct ggml_tensor *prepared_bias2 =
+      prepare_bias_for_add(ctx, u.out_conv_bias, cur);
+  cur = ggml_add(ctx, cur, prepared_bias2);
+  return ggml_add(ctx, cur, residual);
+}
+
+static struct ggml_tensor *build_decoder_block(ggml_context *ctx,
+                                               struct ggml_tensor *cur,
+                                               dac_layer &l,
+                                               struct dac_context *dctx) {
+  cur = snake_1d(ctx, l.snake_alpha_in, cur);
+  struct ggml_tensor *prepared_transpose_kernel =
+      prepare_conv_weight(ctx, l.out_conv_kernel);
+  cur = ggml_conv_transpose_1d(ctx, prepared_transpose_kernel, cur, l.stride, 0,
+                               1); // padding=0 required by mobile branch
+  cur = ggml_add(ctx, cur, prepare_bias_for_add(ctx, l.out_conv_bias, cur));
+  for (int i = 0; i < l.residual_blocks.size(); i++) {
+    cur = build_residual_unit(ctx, cur, l.residual_blocks[i], pow(3, (i + 1)),
+                              pow(3, i));
+  }
+  return cur;
+}
+
+struct dac_context *build_new_dac_context(struct dac_model *model,
+                                          int n_threads, bool use_cpu) {
+  dac_context *dctx = new dac_context(model, n_threads);
+  if (!use_cpu) {
 #ifdef GGML_USE_METAL
-        dctx->backend = ggml_backend_metal_init();
+    dctx->backend = ggml_backend_metal_init();
 #endif
-    }
-    dctx->backend_cpu = ggml_backend_cpu_init();
-    dctx->set_threads();
-    dctx->build_schedule();
-    dctx->buf_compute_meta.resize(ggml_tensor_overhead()*model->max_nodes() + ggml_graph_overhead_custom(model->max_nodes(), false));
-    return dctx;
+  }
+  dctx->backend_cpu = ggml_backend_cpu_init();
+  dctx->set_threads();
+  dctx->build_schedule();
+  dctx->buf_compute_meta.resize(
+      ggml_tensor_overhead() * model->max_nodes() +
+      ggml_graph_overhead_custom(model->max_nodes(), false));
+  return dctx;
 }
 
 void dac_runner::prepare_post_load() {
-    dac_ubatch batch;
-    batch.sequence_length = model->max_generation_size;
-    ggml_cgraph * gf = build_dac_graph(batch);
-    dctx->prep_schedule(gf);
+  dac_ubatch batch;
+  batch.sequence_length = model->max_generation_size;
+  ggml_cgraph *gf = build_dac_graph(batch);
+  dctx->prep_schedule(gf);
 }
-    
-struct ggml_cgraph * dac_runner::build_dac_graph(dac_ubatch & batch) {
-    init_build();
-    // splitting this out from the primary graph so that we can better manage streaming (i.e. sentence chunks are better performed this way)
-    struct ggml_cgraph * gf = ggml_new_graph_custom(ctx, 8192, false);
-    
-    struct ggml_tensor * cur;
-    struct ggml_tensor * inputs;
-    
-    inputs = dac_build_audio_inputs(ctx, dctx, batch, model->quantizer_layers);
-    ggml_set_name(inputs, "quanitzed_inputs");
-    
-    // everything besides the inputs is just a forward pass
-    cur = ggml_conv_1d(ctx, model->in_conv_kernel, inputs, 1, 3, 1);
-    cur = ggml_add(ctx, cur, model->in_conv_bias);
-    for (auto l : model->layers) {
-        cur = build_decoder_block(ctx, cur, l, dctx);
+
+struct ggml_cgraph *dac_runner::build_dac_graph(dac_ubatch &batch) {
+  init_build();
+  // splitting this out from the primary graph so that we can better manage
+  // streaming (i.e. sentence chunks are better performed this way)
+  struct ggml_cgraph *gf = ggml_new_graph_custom(ctx, 8192, false);
+
+  struct ggml_tensor *cur;
+  struct ggml_tensor *inputs;
+
+  inputs = dac_build_audio_inputs(ctx, dctx, batch, model->quantizer_layers);
+  ggml_set_name(inputs, "quanitzed_inputs");
+
+  // everything besides the inputs is just a forward pass
+  struct ggml_tensor *prepared_in_conv_kernel =
+      prepare_conv_weight(ctx, model->in_conv_kernel);
+  cur = ggml_conv_1d(ctx, prepared_in_conv_kernel, inputs, 1, 3, 1);
+  cur = ggml_add(ctx, cur, prepare_bias_for_add(ctx, model->in_conv_bias, cur));
+  for (auto l : model->layers) {
+    cur = build_decoder_block(ctx, cur, l, dctx);
+  }
+  cur = snake_1d(ctx, model->snake_alpha, cur);
+  struct ggml_tensor *prepared_out_conv_kernel =
+      prepare_conv_weight(ctx, model->out_conv_kernel);
+  cur = ggml_conv_1d(ctx, prepared_out_conv_kernel, cur, 1, 3, 1);
+  cur =
+      ggml_add(ctx, cur, prepare_bias_for_add(ctx, model->out_conv_bias, cur));
+  cur = ggml_tanh(ctx, cur);
+  ggml_build_forward_expand(gf, cur);
+  free_build();
+  return gf;
+}
+
+void dac_runner::run(uint32_t *input_tokens, uint32_t sequence_length,
+                     struct tts_response *outputs) {
+  dac_ubatch batch;
+  batch.input_tokens = input_tokens;
+  batch.sequence_length = sequence_length;
+  ggml_backend_sched_reset(dctx->sched);
+
+  const size_t prev_size =
+      dctx->buf_output ? ggml_backend_buffer_get_size(dctx->buf_output) : 0;
+  const size_t new_size =
+      model->max_generation_size * model->up_sampling_factor * sizeof(float);
+
+  if (!dctx->buf_output || prev_size < new_size) {
+    if (dctx->buf_output) {
+      ggml_backend_buffer_free(dctx->buf_output);
+      dctx->buf_output = nullptr;
+      dctx->logits = nullptr;
     }
-    cur = snake_1d(ctx, model->snake_alpha, cur);
-    cur = ggml_conv_1d(ctx, model->out_conv_kernel, cur, 1, 3, 1);
-    cur = ggml_add(ctx, cur, model->out_conv_bias);
-    cur = ggml_tanh(ctx, cur);
-    ggml_build_forward_expand(gf, cur);
-    free_build();
-    return gf;
+
+    dctx->buf_output =
+        ggml_backend_buft_alloc_buffer(dctx->backend_cpu_buffer, new_size);
+  }
+
+  outputs->data = (float *)ggml_backend_buffer_get_base(dctx->buf_output);
+  ggml_backend_buffer_clear(dctx->buf_output, 0);
+
+  struct ggml_cgraph *gf = NULL;
+  gf = build_dac_graph(batch);
+
+  // the output is always the last tensor in the graph
+  struct ggml_tensor *result = ggml_graph_node(gf, -1);
+  ggml_backend_sched_alloc_graph(dctx->sched, gf);
+
+  ggml_backend_tensor_set(dctx->inp_tokens, batch.input_tokens, 0,
+                          batch.sequence_length * model->n_heads *
+                              ggml_element_size(dctx->inp_tokens));
+
+  ggml_backend_sched_graph_compute_async(dctx->sched, gf);
+
+  dctx->get_ggml_node_data(result, outputs->data,
+                           batch.sequence_length * sizeof(float) *
+                               model->up_sampling_factor);
+
+  // Reset state for the next token before backend sync, to allow the CPU
+  // activities in the reset to overlap with device computation.
+  ggml_backend_sched_reset(dctx->sched);
+  outputs->n_outputs = sequence_length * model->up_sampling_factor;
+  return;
 }
-
-void dac_runner::run(uint32_t * input_tokens, uint32_t sequence_length, struct tts_response * outputs) {
-    dac_ubatch batch;
-    batch.input_tokens = input_tokens;
-    batch.sequence_length = sequence_length;
-    ggml_backend_sched_reset(dctx->sched);
-    
-    const size_t prev_size = dctx->buf_output ? ggml_backend_buffer_get_size(dctx->buf_output) : 0;
-    const size_t new_size = model->max_generation_size * model->up_sampling_factor * sizeof(float);
-    
-    if (!dctx->buf_output || prev_size < new_size) {
-        if (dctx->buf_output) {
-            ggml_backend_buffer_free(dctx->buf_output);
-            dctx->buf_output = nullptr;
-            dctx->logits = nullptr;
-        }
-
-        dctx->buf_output = ggml_backend_buft_alloc_buffer(dctx->backend_cpu_buffer, new_size);
-    }
-    
-    outputs->data = (float *) ggml_backend_buffer_get_base(dctx->buf_output);
-    ggml_backend_buffer_clear(dctx->buf_output, 0);
-    
-    struct ggml_cgraph * gf = NULL;
-    gf = build_dac_graph(batch);
-    
-    // the output is always the last tensor in the graph
-    struct ggml_tensor * result = gf->nodes[gf->n_nodes - 1];
-    ggml_backend_sched_alloc_graph(dctx->sched, gf);
-    
-    ggml_backend_tensor_set(dctx->inp_tokens, batch.input_tokens, 0, batch.sequence_length*model->n_heads*ggml_element_size(dctx->inp_tokens));
-
-    ggml_backend_sched_graph_compute_async(dctx->sched, gf);
-
-    dctx->get_ggml_node_data(result, outputs->data, batch.sequence_length*sizeof(float)*model->up_sampling_factor);
-
-    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
-    // overlap with device computation.
-    ggml_backend_sched_reset(dctx->sched);
-    outputs->n_outputs = sequence_length * model->up_sampling_factor;
-    return;
-}
-

--- a/src/dac_model.h
+++ b/src/dac_model.h
@@ -5,135 +5,152 @@
 #include <map>
 
 enum dac_tensor {
-    DAC_ENCODER_IN_KERNEL,
-    DAC_ENCODER_IN_BIAS,
-    DAC_ENCODER_OUT_KERNEL,
-    DAC_ENCODER_OUT_BIAS,
-    DAC_ENCODER_SNAKE_ALPHA,
-    DAC_ENCODER_LAYER_SNAKE_ALPHA,
-    DAC_ENCODER_LAYER_OUT_KERNEL,
-    DAC_ENCODER_LAYER_OUT_BIAS,
-    DAC_ENCODER_LAYER_RES_BLK_IN_SNAKE,
-    DAC_ENCODER_LAYER_RES_BLK_OUT_SNAKE,
-    DAC_ENCODER_LAYER_RES_BLK_IN_KERNEL,
-    DAC_ENCODER_LAYER_RES_BLK_OUT_KERNEL,
-    DAC_ENCODER_LAYER_RES_BLK_IN_BIAS,
-    DAC_ENCODER_LAYER_RES_BLK_OUT_BIAS,
-    DAC_QUANTIZER_LAYER_IN_KERNEL,
-    DAC_QUANTIZER_LAYER_IN_BIAS,
-    DAC_QUANTIZER_LAYER_OUT_KERNEL,
-    DAC_QUANTIZER_LAYER_OUT_BIAS,
-    DAC_QUANTIZER_LAYER_CODEBOOK
+  DAC_ENCODER_IN_KERNEL,
+  DAC_ENCODER_IN_BIAS,
+  DAC_ENCODER_OUT_KERNEL,
+  DAC_ENCODER_OUT_BIAS,
+  DAC_ENCODER_SNAKE_ALPHA,
+  DAC_ENCODER_LAYER_SNAKE_ALPHA,
+  DAC_ENCODER_LAYER_OUT_KERNEL,
+  DAC_ENCODER_LAYER_OUT_BIAS,
+  DAC_ENCODER_LAYER_RES_BLK_IN_SNAKE,
+  DAC_ENCODER_LAYER_RES_BLK_OUT_SNAKE,
+  DAC_ENCODER_LAYER_RES_BLK_IN_KERNEL,
+  DAC_ENCODER_LAYER_RES_BLK_OUT_KERNEL,
+  DAC_ENCODER_LAYER_RES_BLK_IN_BIAS,
+  DAC_ENCODER_LAYER_RES_BLK_OUT_BIAS,
+  DAC_QUANTIZER_LAYER_IN_KERNEL,
+  DAC_QUANTIZER_LAYER_IN_BIAS,
+  DAC_QUANTIZER_LAYER_OUT_KERNEL,
+  DAC_QUANTIZER_LAYER_OUT_BIAS,
+  DAC_QUANTIZER_LAYER_CODEBOOK
 };
 
 struct dac_residual_unit {
-    struct ggml_tensor * in_snake_alpha;
-    struct ggml_tensor * in_conv_kernel;
-    struct ggml_tensor * in_conv_bias;
-    struct ggml_tensor * out_snake_alpha;
-    struct ggml_tensor * out_conv_kernel;
-    struct ggml_tensor * out_conv_bias;
+  struct ggml_tensor *in_snake_alpha;
+  struct ggml_tensor *in_conv_kernel;
+  struct ggml_tensor *in_conv_bias;
+  struct ggml_tensor *out_snake_alpha;
+  struct ggml_tensor *out_conv_kernel;
+  struct ggml_tensor *out_conv_bias;
 };
 
 struct dac_layer {
-    struct ggml_tensor * snake_alpha_in;
-    struct ggml_tensor * out_conv_kernel;
-    struct ggml_tensor * out_conv_bias;
+  struct ggml_tensor *snake_alpha_in;
+  struct ggml_tensor *out_conv_kernel;
+  struct ggml_tensor *out_conv_bias;
 
-    uint32_t padding;
-    uint32_t stride;
-    
-    std::vector<dac_residual_unit> residual_blocks;
+  uint32_t padding;
+  uint32_t stride;
+
+  std::vector<dac_residual_unit> residual_blocks;
 };
 
 struct dac_quantize_layer {
-    struct ggml_tensor * out_proj_kernel;
-    struct ggml_tensor * out_proj_bias;
-    struct ggml_tensor * codebook;
+  struct ggml_tensor *out_proj_kernel;
+  struct ggml_tensor *out_proj_bias;
+  struct ggml_tensor *codebook;
 };
 
 // this struct maintains the static tensors for the dac audio decoder graph.
-// As such, this is designed to contain basic configuration and ggml tensor support for DAC.
-// The dac_runner describes how the graph is built and run.
-struct dac_model : tts_model {    
-    // These configs  are essentially built for the 44khZ 8kbps standard DAC model audio encoder and decoder
-    uint32_t n_layers = 4;
-    uint32_t n_heads = 9;
-    uint32_t up_sampling_factor = 512;
-    uint32_t max_generation_size = 2580;
-    
-    struct ggml_tensor * in_conv_kernel;
-    struct ggml_tensor * in_conv_bias;
-    struct ggml_tensor * out_conv_kernel;
-    struct ggml_tensor * out_conv_bias;
-    struct ggml_tensor * snake_alpha;
-    std::vector<dac_layer> layers;
-    std::vector<dac_quantize_layer> quantizer_layers;
+// As such, this is designed to contain basic configuration and ggml tensor
+// support for DAC. The dac_runner describes how the graph is built and run.
+struct dac_model : tts_model {
+  // These configs  are essentially built for the 44khZ 8kbps standard DAC model
+  // audio encoder and decoder
+  uint32_t n_layers = 4;
+  uint32_t n_heads = 9;
+  uint32_t up_sampling_factor = 512;
+  uint32_t max_generation_size = 2580;
 
-    void assign_weight(std::string name, ggml_tensor * weight);
-    void prep_constants(gguf_context * meta);
-    void prep_layers(gguf_context * meta);
-    void setup_from_file(gguf_context * meta_ctx, ggml_context * load_context, bool cpu_only) {
-        prep_layers(meta_ctx);
-        prep_constants(meta_ctx);
-        tts_model::setup_from_file(meta_ctx, load_context, cpu_only, "audio_encoder");
-    }
+  struct ggml_tensor *in_conv_kernel;
+  struct ggml_tensor *in_conv_bias;
+  struct ggml_tensor *out_conv_kernel;
+  struct ggml_tensor *out_conv_bias;
+  struct ggml_tensor *snake_alpha;
+  std::vector<dac_layer> layers;
+  std::vector<dac_quantize_layer> quantizer_layers;
+
+  void assign_weight(std::string name, ggml_tensor *weight);
+  void prep_constants(gguf_context *meta);
+  void prep_layers(gguf_context *meta);
+  void setup_from_file(gguf_context *meta_ctx, ggml_context *load_context,
+                       bool cpu_only) {
+    prep_layers(meta_ctx);
+    prep_constants(meta_ctx);
+    tts_model::setup_from_file(meta_ctx, load_context, cpu_only,
+                               "audio_encoder");
+  }
 };
 
 // for loading DAC model from gguf file
-void assign_residual_unit(dac_model * model, dac_residual_unit * layer, std::string name, ggml_tensor * tensor);
-void assign_dac_layer(dac_model * model, dac_layer * layer, std::string name, ggml_tensor * tensor);
-void assign_quantizer_layer(dac_model * model, dac_quantize_layer  layer, std::string name, ggml_tensor * tensor);
-void assign_to_audio_encoder(dac_model * model, std::string name, ggml_tensor * tensor);
+void assign_residual_unit(dac_model *model, dac_residual_unit *layer,
+                          std::string name, ggml_tensor *tensor);
+void assign_dac_layer(dac_model *model, dac_layer *layer, std::string name,
+                      ggml_tensor *tensor);
+void assign_quantizer_layer(dac_model *model, dac_quantize_layer layer,
+                            std::string name, ggml_tensor *tensor);
+void assign_to_audio_encoder(dac_model *model, std::string name,
+                             ggml_tensor *tensor);
 
 // the context used for running the dac model
 struct dac_context : runner_context {
-    dac_context(dac_model * model, int n_threads): runner_context(n_threads), model(model) {};
-    
-    struct dac_model * model;
-    
-    size_t  logits_size = 0; // capacity (of floats) for logits
-    float * logits      = nullptr;
-    
-    struct ggml_tensor * inp_tokens;
-    
-    void build_schedule() {
-        runner_context::build_schedule(model->max_nodes());
-    }
+  dac_context(dac_model *model, int n_threads)
+      : runner_context(n_threads), model(model){};
+
+  struct dac_model *model;
+
+  size_t logits_size = 0; // capacity (of floats) for logits
+  float *logits = nullptr;
+
+  struct ggml_tensor *inp_tokens;
+
+  void build_schedule() { runner_context::build_schedule(model->max_nodes()); }
 };
 
-struct dac_context * build_new_dac_context(struct dac_model * model, int n_threads, bool use_cpu = true);
+struct dac_context *build_new_dac_context(struct dac_model *model,
+                                          int n_threads, bool use_cpu = true);
 
 struct dac_ubatch {
-    uint32_t * input_tokens;
-    uint32_t sequence_length;
+  uint32_t *input_tokens;
+  uint32_t sequence_length;
 };
 
-static struct ggml_tensor * dac_build_audio_inputs(struct ggml_context * ctx, struct dac_context * dctx, const dac_ubatch & batch, std::vector<dac_quantize_layer> layers);
-static struct ggml_tensor * build_residual_unit(ggml_context * ctx, struct ggml_tensor * cur, dac_residual_unit & u, int padding, int dilation);
-static struct ggml_tensor * build_decoder_block(ggml_context * ctx, struct ggml_tensor * cur, dac_layer & l, struct dac_context * dctx);
+static struct ggml_tensor *
+dac_build_audio_inputs(struct ggml_context *ctx, struct dac_context *dctx,
+                       const dac_ubatch &batch,
+                       std::vector<dac_quantize_layer> layers);
+static struct ggml_tensor *build_residual_unit(ggml_context *ctx,
+                                               struct ggml_tensor *cur,
+                                               dac_residual_unit &u,
+                                               int padding, int dilation);
+static struct ggml_tensor *build_decoder_block(ggml_context *ctx,
+                                               struct ggml_tensor *cur,
+                                               dac_layer &l,
+                                               struct dac_context *dctx);
 
-// This struct is intended to manage the dac model's graph compilation and compute function.
+// This struct is intended to manage the dac model's graph compilation and
+// compute function.
 struct dac_runner : tts_runner {
-    dac_runner(dac_model * model, dac_context * context): model(model), dctx(context) {};
-    ~dac_runner() {
-        if (ctx) {
-            ggml_free(ctx);
-        }
-        model->free();
-        delete model;
-        delete dctx;
+  dac_runner(dac_model *model, dac_context *context)
+      : model(model), dctx(context){};
+  ~dac_runner() {
+    if (ctx) {
+      ggml_free(ctx);
     }
-    dac_model * model;
-    dac_context * dctx;
-    
-    void init_build() {
-        tts_runner::init_build(&dctx->buf_compute_meta);
-    }
-    
-    void prepare_post_load();
-    struct ggml_cgraph * build_dac_graph(dac_ubatch & batch);
-    void run(uint32_t * input_tokens, uint32_t sequence_length, struct tts_response * outputs);
+    model->free();
+    delete model;
+    delete dctx;
+  }
+  dac_model *model;
+  dac_context *dctx;
+
+  void init_build() { tts_runner::init_build(&dctx->buf_compute_meta); }
+
+  void prepare_post_load();
+  struct ggml_cgraph *build_dac_graph(dac_ubatch &batch);
+  void run(uint32_t *input_tokens, uint32_t sequence_length,
+           struct tts_response *outputs);
 };
 
 #endif

--- a/src/dia_model.cpp
+++ b/src/dia_model.cpp
@@ -1,911 +1,1150 @@
 #include "dia_model.h"
 
-void dia_model::assign_weight(std::string name, struct ggml_tensor * tensor) {
-    std::vector<std::string> parts = split(name, ".");
-    TTS_ASSERT(parts.size() >= 3);
+void dia_model::assign_weight(std::string name, struct ggml_tensor *tensor) {
+  std::vector<std::string> parts = split(name, ".");
 
-    if (parts[1] == "encoder") {
-        assign_to_encoder(parts, tensor, name);
-    } else if (parts[1] == "decoder"){
-        assign_to_decoder(parts, tensor, name);
-    } else {
-        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
-    }
+  // Skip tensors that don't follow the expected naming convention (like
+  // metadata tensors)
+  if (parts.size() < 3) {
+    return;
+  }
+
+  TTS_ASSERT(parts.size() >= 3);
+
+  if (parts[1] == "encoder") {
+    assign_to_encoder(parts, tensor, name);
+  } else if (parts[1] == "decoder") {
+    assign_to_decoder(parts, tensor, name);
+  } else {
+    TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.",
+              name.c_str());
+  }
 }
 
-void dia_model::assign_to_encoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name) {
-    if (parts[2] == "embedding") {
-        encoder->embedding = ggml_dup_tensor(ctx, tensor);
-        set_tensor(encoder->embedding, tensor);
-    } else if (parts[2] == "norm") {
-        encoder->norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(encoder->norm, tensor);
-    } else if (parts[2] == "layers") {
-        TTS_ASSERT(parts.size() >= 4);
-        int index = std::stoi(parts[3]);
-        TTS_ASSERT(index < decoder->layers.size());
-        assign_to_encoder_layer(parts[4], encoder->layers[index], tensor);
-    } else {
-        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
-    }
+void dia_model::assign_to_encoder(std::vector<std::string> parts,
+                                  struct ggml_tensor *tensor,
+                                  std::string name) {
+  if (parts[2] == "embedding") {
+    encoder->embedding = ggml_dup_tensor(ctx, tensor);
+    set_tensor(encoder->embedding, tensor);
+  } else if (parts[2] == "norm") {
+    encoder->norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(encoder->norm, tensor);
+  } else if (parts[2] == "layers") {
+    TTS_ASSERT(parts.size() >= 4);
+    int index = std::stoi(parts[3]);
+    TTS_ASSERT(index < decoder->layers.size());
+    assign_to_encoder_layer(parts[4], encoder->layers[index], tensor);
+  } else {
+    TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.",
+              name.c_str());
+  }
 }
 
-void dia_model::assign_to_decoder(std::vector<std::string> parts, struct ggml_tensor * tensor, std::string name) {
-    if (parts[2] == "embeddings") {
-        TTS_ASSERT(parts.size() > 2);
-        int index = std::stoi(parts[3]);
-        TTS_ASSERT(index < decoder->embds.size());
-        decoder->embds[index] = ggml_dup_tensor(ctx, tensor);
-        set_tensor(decoder->embds[index], tensor);
-    } else if (parts[2] == "norm") {
-        decoder->norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(decoder->norm, tensor);
-    } else if (parts[2] == "heads") {
-        TTS_ASSERT(parts.size() > 2);
-        int index = std::stoi(parts[3]);
-        TTS_ASSERT(index < decoder->heads.size());
-        decoder->heads[index] = ggml_dup_tensor(ctx, tensor);
-        set_tensor(decoder->heads[index], tensor);
-    } else if (parts[2] == "layers") {
-        TTS_ASSERT(parts.size() >= 4);
-        int index = std::stoi(parts[3]);
-        TTS_ASSERT(index < decoder->layers.size());
-        assign_to_decoder_layer(parts[4], decoder->layers[index], tensor);
-    } else {
-        TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.", name.c_str());
-    }
+void dia_model::assign_to_decoder(std::vector<std::string> parts,
+                                  struct ggml_tensor *tensor,
+                                  std::string name) {
+  if (parts[2] == "embeddings") {
+    TTS_ASSERT(parts.size() > 2);
+    int index = std::stoi(parts[3]);
+    TTS_ASSERT(index < decoder->embds.size());
+    decoder->embds[index] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->embds[index], tensor);
+  } else if (parts[2] == "norm") {
+    decoder->norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->norm, tensor);
+  } else if (parts[2] == "heads") {
+    TTS_ASSERT(parts.size() > 2);
+    int index = std::stoi(parts[3]);
+    TTS_ASSERT(index < decoder->heads.size());
+    decoder->heads[index] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->heads[index], tensor);
+  } else if (parts[2] == "layers") {
+    TTS_ASSERT(parts.size() >= 4);
+    int index = std::stoi(parts[3]);
+    TTS_ASSERT(index < decoder->layers.size());
+    assign_to_decoder_layer(parts[4], decoder->layers[index], tensor);
+  } else {
+    TTS_ABORT("Unrecognized tensor '%s' when loading Dia from GGUF file.",
+              name.c_str());
+  }
 }
 
-void dia_model::assign_to_encoder_layer(std::string part, dia_encoder_layer * layer, struct ggml_tensor * tensor) {
-    if (part == "q_proj") {
-        layer->q = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->q, tensor);
-    } else if (part == "k_proj") {
-        layer->k = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->k, tensor);
-    } else if (part == "v_proj") {
-        layer->v = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->v, tensor);
-    } else if (part == "o_proj") {
-        layer->o = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->o, tensor);
-    } else if (part == "pre_sa_norm") {
-        layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_norm, tensor);
-    } else if (part == "post_sa_norm") {
-        layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->mlp_norm, tensor);
-    } else if (part == "gate") {
-        layer->gate = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->gate, tensor);
-    } else if (part == "up") {
-        layer->up = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->up, tensor);
-    } else if (part == "wo") {
-        layer->out = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->out, tensor);
-    } else {
-        TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia from GGUF file.", part.c_str());
-    }
+void dia_model::assign_to_encoder_layer(std::string part,
+                                        dia_encoder_layer *layer,
+                                        struct ggml_tensor *tensor) {
+  if (part == "q_proj") {
+    layer->q = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->q, tensor);
+  } else if (part == "k_proj") {
+    layer->k = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->k, tensor);
+  } else if (part == "v_proj") {
+    layer->v = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->v, tensor);
+  } else if (part == "o_proj") {
+    layer->o = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->o, tensor);
+  } else if (part == "pre_sa_norm") {
+    layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_norm, tensor);
+  } else if (part == "post_sa_norm") {
+    layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->mlp_norm, tensor);
+  } else if (part == "gate") {
+    layer->gate = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->gate, tensor);
+  } else if (part == "up") {
+    layer->up = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->up, tensor);
+  } else if (part == "wo") {
+    layer->out = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->out, tensor);
+  } else {
+    TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia "
+              "from GGUF file.",
+              part.c_str());
+  }
 }
 
-void dia_model::assign_to_decoder_layer(std::string part, dia_decoder_layer * layer, struct ggml_tensor * tensor) {
-    if (part == "self_q_proj") {
-        layer->self_attn_q = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_q, tensor);
-    } else if (part == "self_k_proj") {
-        layer->self_attn_k = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_k, tensor);
-    } else if (part == "self_v_proj") {
-        layer->self_attn_v = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_v, tensor);
-    } else if (part == "self_o_proj") {
-        layer->self_attn_o = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_o, tensor);
-    } else if (part == "cross_q_proj") {
-        layer->cross_attn_q = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->cross_attn_q, tensor);
-    } else if (part == "cross_k_proj") {
-        layer->cross_attn_k = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->cross_attn_k, tensor);
-    } else if (part == "cross_v_proj") {
-        layer->cross_attn_v = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->cross_attn_v, tensor);
-    } else if (part == "cross_o_proj") {
-        layer->cross_attn_o = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->cross_attn_o, tensor);
-    } else if (part == "pre_sa_norm") {
-        layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->self_attn_norm, tensor);
-    } else if (part == "pre_mlp_norm") {
-        layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->mlp_norm, tensor);    
-    } else if (part == "pre_ca_norm") {
-        layer->cross_attn_norm = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->cross_attn_norm, tensor);
-    } else if (part == "gate") {
-        layer->gate = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->gate, tensor);
-    } else if (part == "up") {
-        layer->up = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->up, tensor);
-    } else if (part == "wo") {
-        layer->out = ggml_dup_tensor(ctx, tensor);
-        set_tensor(layer->out, tensor);
-    } else {
-        TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia from GGUF file.", part.c_str());
-    }
+void dia_model::assign_to_decoder_layer(std::string part,
+                                        dia_decoder_layer *layer,
+                                        struct ggml_tensor *tensor) {
+  if (part == "self_q_proj") {
+    layer->self_attn_q = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_q, tensor);
+  } else if (part == "self_k_proj") {
+    layer->self_attn_k = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_k, tensor);
+  } else if (part == "self_v_proj") {
+    layer->self_attn_v = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_v, tensor);
+  } else if (part == "self_o_proj") {
+    layer->self_attn_o = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_o, tensor);
+  } else if (part == "cross_q_proj") {
+    layer->cross_attn_q = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->cross_attn_q, tensor);
+  } else if (part == "cross_k_proj") {
+    layer->cross_attn_k = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->cross_attn_k, tensor);
+  } else if (part == "cross_v_proj") {
+    layer->cross_attn_v = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->cross_attn_v, tensor);
+  } else if (part == "cross_o_proj") {
+    layer->cross_attn_o = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->cross_attn_o, tensor);
+  } else if (part == "pre_sa_norm") {
+    layer->self_attn_norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->self_attn_norm, tensor);
+  } else if (part == "pre_mlp_norm") {
+    layer->mlp_norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->mlp_norm, tensor);
+  } else if (part == "pre_ca_norm") {
+    layer->cross_attn_norm = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->cross_attn_norm, tensor);
+  } else if (part == "gate") {
+    layer->gate = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->gate, tensor);
+  } else if (part == "up") {
+    layer->up = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->up, tensor);
+  } else if (part == "wo") {
+    layer->out = ggml_dup_tensor(ctx, tensor);
+    set_tensor(layer->out, tensor);
+  } else {
+    TTS_ABORT("Unrecognized tensor '%s' for encoder layer when loading Dia "
+              "from GGUF file.",
+              part.c_str());
+  }
 }
 
 void dia_model::prep_layers() {
-    encoder = new dia_encoder;
-    decoder = new dia_decoder;
-    encoder->layers.reserve((size_t) n_encoder_layers);
-    for (int i = 0; i < (int) n_encoder_layers; i++) {
-        dia_encoder_layer * l = new dia_encoder_layer;
-        encoder->layers.push_back(l);
-    }
+  encoder = new dia_encoder;
+  decoder = new dia_decoder;
+  encoder->layers.reserve((size_t)n_encoder_layers);
+  for (int i = 0; i < (int)n_encoder_layers; i++) {
+    dia_encoder_layer *l = new dia_encoder_layer;
+    encoder->layers.push_back(l);
+  }
 
-    decoder->layers.reserve((size_t) n_decoder_layers);
-    for (int i = 0; i < (int) n_decoder_layers; i++) {
-        dia_decoder_layer * l = new dia_decoder_layer;
-        decoder->layers.push_back(l);
-    }
-    
-    decoder->embds.reserve((size_t) n_output_heads);
-    decoder->heads.reserve((size_t) n_output_heads);
-    for (int i = 0; i < n_output_heads; i++) {
-        struct ggml_tensor * h = nullptr;
-        struct ggml_tensor * embd = nullptr;
-        decoder->embds.push_back(embd);
-        decoder->heads.push_back(h);
-    }
+  decoder->layers.reserve((size_t)n_decoder_layers);
+  for (int i = 0; i < (int)n_decoder_layers; i++) {
+    dia_decoder_layer *l = new dia_decoder_layer;
+    decoder->layers.push_back(l);
+  }
+
+  decoder->embds.reserve((size_t)n_output_heads);
+  decoder->heads.reserve((size_t)n_output_heads);
+  for (int i = 0; i < n_output_heads; i++) {
+    struct ggml_tensor *h = nullptr;
+    struct ggml_tensor *embd = nullptr;
+    decoder->embds.push_back(embd);
+    decoder->heads.push_back(h);
+  }
 }
 
-void dia_model::prep_constants(gguf_context * meta) {
-    int output_heads_key = gguf_find_key(meta, "dia.decoder.output_heads");
-    if (output_heads_key != -1) {
-        n_output_heads = gguf_get_val_u32(meta, output_heads_key);
-    }
+void dia_model::prep_constants(gguf_context *meta) {
+  int output_heads_key = gguf_find_key(meta, "dia.decoder.output_heads");
+  if (output_heads_key != -1) {
+    n_output_heads = gguf_get_val_u32(meta, output_heads_key);
+  }
 
-    int decoder_layers_key = gguf_find_key(meta, "dia.decoder.layers");
-    if (decoder_layers_key != -1) {
-        n_decoder_layers = gguf_get_val_u32(meta, decoder_layers_key);
-    }
+  int decoder_layers_key = gguf_find_key(meta, "dia.decoder.layers");
+  if (decoder_layers_key != -1) {
+    n_decoder_layers = gguf_get_val_u32(meta, decoder_layers_key);
+  }
 
-    int encoder_layers_key = gguf_find_key(meta, "dia.encoder.layers");
-    if (encoder_layers_key != -1) {
-        n_encoder_layers = gguf_get_val_u32(meta, encoder_layers_key);
-    }
+  int encoder_layers_key = gguf_find_key(meta, "dia.encoder.layers");
+  if (encoder_layers_key != -1) {
+    n_encoder_layers = gguf_get_val_u32(meta, encoder_layers_key);
+  }
 
-    int decoder_hidden_size_key = gguf_find_key(meta, "dia.decoder.hidden_size");
-    if (decoder_hidden_size_key != -1) {
-        decoder_hidden_size = gguf_get_val_u32(meta, decoder_hidden_size_key);
-    }
+  int decoder_hidden_size_key = gguf_find_key(meta, "dia.decoder.hidden_size");
+  if (decoder_hidden_size_key != -1) {
+    decoder_hidden_size = gguf_get_val_u32(meta, decoder_hidden_size_key);
+  }
 
-    int decoder_attn_heads_key = gguf_find_key(meta, "dia.decoder.attn_heads");
-    if (decoder_attn_heads_key != -1) {
-        decoder_attn_heads = gguf_get_val_u32(meta, decoder_attn_heads_key);
-    }
+  int decoder_attn_heads_key = gguf_find_key(meta, "dia.decoder.attn_heads");
+  if (decoder_attn_heads_key != -1) {
+    decoder_attn_heads = gguf_get_val_u32(meta, decoder_attn_heads_key);
+  }
 
-    int decoder_query_heads_key = gguf_find_key(meta, "dia.decoder.query_heads");
-    if (decoder_query_heads_key != -1) {
-        decoder_query_heads = gguf_get_val_u32(meta, decoder_query_heads_key);
-    }
+  int decoder_query_heads_key = gguf_find_key(meta, "dia.decoder.query_heads");
+  if (decoder_query_heads_key != -1) {
+    decoder_query_heads = gguf_get_val_u32(meta, decoder_query_heads_key);
+  }
 
-    int encoder_attn_heads_key = gguf_find_key(meta, "dia.encoder.attn_heads");
-    if (encoder_attn_heads_key != -1) {
-        encoder_attn_heads = gguf_get_val_u32(meta, encoder_attn_heads_key);
-    }    
+  int encoder_attn_heads_key = gguf_find_key(meta, "dia.encoder.attn_heads");
+  if (encoder_attn_heads_key != -1) {
+    encoder_attn_heads = gguf_get_val_u32(meta, encoder_attn_heads_key);
+  }
 
-    int head_size_key = gguf_find_key(meta, "dia.attn_head_size");
-    if (head_size_key != -1) {
-        head_size = gguf_get_val_u32(meta, head_size_key);
-    }
+  int head_size_key = gguf_find_key(meta, "dia.attn_head_size");
+  if (head_size_key != -1) {
+    head_size = gguf_get_val_u32(meta, head_size_key);
+  }
 
-    int eos_token_id_key = gguf_find_key(meta, "dia.eos_token_id");
-    if (eos_token_id_key != -1) {
-        eos_token_id = gguf_get_val_u32(meta, eos_token_id_key);
-    }
+  int eos_token_id_key = gguf_find_key(meta, "dia.eos_token_id");
+  if (eos_token_id_key != -1) {
+    eos_token_id = gguf_get_val_u32(meta, eos_token_id_key);
+  }
 
-    int bos_token_id_key = gguf_find_key(meta, "dia.bos_token_id");
-    if (bos_token_id_key != -1) {
-        bos_token_id = gguf_get_val_u32(meta, bos_token_id_key);
-    }
+  int bos_token_id_key = gguf_find_key(meta, "dia.bos_token_id");
+  if (bos_token_id_key != -1) {
+    bos_token_id = gguf_get_val_u32(meta, bos_token_id_key);
+  }
 
-    int pad_token_id_key = gguf_find_key(meta, "dia.pad_token_id");
-    if (pad_token_id_key != -1) {
-        pad_token_id = gguf_get_val_u32(meta, pad_token_id_key);
-    }
+  int pad_token_id_key = gguf_find_key(meta, "dia.pad_token_id");
+  if (pad_token_id_key != -1) {
+    pad_token_id = gguf_get_val_u32(meta, pad_token_id_key);
+  }
 
-    int max_context_key = gguf_find_key(meta, "dia.encoder.max_context_length");
-    if (max_context_key != -1) {
-        max_encoder_context_length = gguf_get_val_u32(meta, max_context_key);
-    }
+  int max_context_key = gguf_find_key(meta, "dia.encoder.max_context_length");
+  if (max_context_key != -1) {
+    max_encoder_context_length = gguf_get_val_u32(meta, max_context_key);
+  }
 
-    int output_vocab_size_key = gguf_find_key(meta, "dia.decoder.output_vocab_size");
-    if (output_vocab_size_key != -1) {
-        output_vocab_size = gguf_get_val_u32(meta, output_vocab_size_key);
-    }
+  int output_vocab_size_key =
+      gguf_find_key(meta, "dia.decoder.output_vocab_size");
+  if (output_vocab_size_key != -1) {
+    output_vocab_size = gguf_get_val_u32(meta, output_vocab_size_key);
+  }
 
-    int audio_vocab_size_key = gguf_find_key(meta, "dia.decoder.audio_vocab_size");
-    if (audio_vocab_size_key != -1) {
-        audio_vocab_size = gguf_get_val_u32(meta, audio_vocab_size_key);
-    }
+  int audio_vocab_size_key =
+      gguf_find_key(meta, "dia.decoder.audio_vocab_size");
+  if (audio_vocab_size_key != -1) {
+    audio_vocab_size = gguf_get_val_u32(meta, audio_vocab_size_key);
+  }
 
-    int max_generation_size_key = gguf_find_key(meta, "dia.decoder.max_generation_size");
-    if (max_generation_size_key != -1) {
-        max_generation_size = gguf_get_val_u32(meta, max_generation_size_key);
-    }
-    int max_delay_key = gguf_find_key(meta, "dia.max_delay");
-    if (max_delay_key != -1) {
-        max_delay = gguf_get_val_u32(meta, max_delay_key);
-    }
+  int max_generation_size_key =
+      gguf_find_key(meta, "dia.decoder.max_generation_size");
+  if (max_generation_size_key != -1) {
+    max_generation_size = gguf_get_val_u32(meta, max_generation_size_key);
+  }
+  int max_delay_key = gguf_find_key(meta, "dia.max_delay");
+  if (max_delay_key != -1) {
+    max_delay = gguf_get_val_u32(meta, max_delay_key);
+  }
 
-    // please note that this value is not currently set in the gguf encoder as it effectively only exists as a default
-    // python parameter (rather than an attribute in the model config) for the python Dia model.
-    int cfg_scale_key = gguf_find_key(meta, "dia.cfg_scale");
-    if (cfg_scale_key != -1) {
-        cfg_scale_data[0] = gguf_get_val_f32(meta, cfg_scale_key);
-    }
+  // please note that this value is not currently set in the gguf encoder as it
+  // effectively only exists as a default python parameter (rather than an
+  // attribute in the model config) for the python Dia model.
+  int cfg_scale_key = gguf_find_key(meta, "dia.cfg_scale");
+  if (cfg_scale_key != -1) {
+    cfg_scale_data[0] = gguf_get_val_f32(meta, cfg_scale_key);
+  }
 }
 
 void dia_context::reset() {
-    current_position = 0;
-    prompt_size = 0;
-    output_tokens.clear();
-    delay_steps = -1;
+  current_position = 0;
+  prompt_size = 0;
+  output_tokens.clear();
+  delay_steps = -1;
 }
 
-struct dia_context * build_new_dia_context(struct dia_model * model, int n_threads, bool use_cpu) {
-    dia_context * dctx = new dia_context(model, n_threads);
-    if (!use_cpu) {
+struct dia_context *build_new_dia_context(struct dia_model *model,
+                                          int n_threads, bool use_cpu) {
+  dia_context *dctx = new dia_context(model, n_threads);
+  if (!use_cpu) {
 #ifdef GGML_USE_METAL
-        dctx->backend = ggml_backend_metal_init();
+    dctx->backend = ggml_backend_metal_init();
 #endif
-    }
-    dctx->backend_cpu = ggml_backend_cpu_init();
-    dctx->set_threads();
-    dctx->build_schedule();
-    dctx->buf_compute_meta.resize(ggml_tensor_overhead()*model->max_nodes() + ggml_graph_overhead_custom(model->max_nodes(), false));
-    return dctx;
+  }
+  dctx->backend_cpu = ggml_backend_cpu_init();
+  dctx->set_threads();
+  dctx->build_schedule();
+  dctx->buf_compute_meta.resize(
+      ggml_tensor_overhead() * model->max_nodes() +
+      ggml_graph_overhead_custom(model->max_nodes(), false));
+  return dctx;
 }
 
-static bool dia_kv_cache_init(struct dia_kv_cache * cache, dia_model * model, dia_context * dctx) {    
-    ggml_backend_buffer_type_t buft = nullptr;
-    // this will only really support cpu or metal for the time being;
-    if (dctx->backend != nullptr) {
+static bool dia_kv_cache_init(struct dia_kv_cache *cache, dia_model *model,
+                              dia_context *dctx) {
+  ggml_backend_buffer_type_t buft = nullptr;
+  // this will only really support cpu or metal for the time being;
+  if (dctx->backend != nullptr) {
 #ifdef GGML_USE_METAL
-        buft = ggml_backend_metal_buffer_type();
+    buft = ggml_backend_metal_buffer_type();
 #endif
+  } else {
+    buft = ggml_backend_cpu_buffer_type();
+  }
+
+  struct ggml_init_params params = {
+      /*.mem_size   =*/(4u * model->n_decoder_layers + 1) *
+          ggml_tensor_overhead(),
+      /*.mem_buffer =*/NULL,
+      /*.no_alloc   =*/true,
+  };
+  ggml_context *ctx = ggml_init(params);
+  if (!ctx) {
+    return false;
+  }
+  cache->ctx = ctx;
+
+  cache->k_l.reserve(model->n_decoder_layers);
+  cache->v_l.reserve(model->n_decoder_layers);
+  cache->cross_k_l.reserve(model->n_decoder_layers);
+  cache->cross_v_l.reserve(model->n_decoder_layers);
+
+  for (int i = 0; i < (int)model->n_decoder_layers; i++) {
+    struct ggml_tensor *k =
+        ggml_new_tensor_1d(cache->ctx, cache->tensor_type,
+                           model->head_size * model->decoder_attn_heads *
+                               model->max_generation_size * 2);
+    struct ggml_tensor *v =
+        ggml_new_tensor_1d(cache->ctx, cache->tensor_type,
+                           model->head_size * model->decoder_attn_heads *
+                               model->max_generation_size * 2);
+    struct ggml_tensor *cross_k =
+        ggml_new_tensor_1d(cache->ctx, cache->tensor_type,
+                           model->head_size * model->decoder_attn_heads *
+                               model->max_encoder_context_length * 2);
+    struct ggml_tensor *cross_v =
+        ggml_new_tensor_1d(cache->ctx, cache->tensor_type,
+                           model->head_size * model->decoder_attn_heads *
+                               model->max_encoder_context_length * 2);
+    ggml_format_name(k, "cache_k_l%d", i);
+    ggml_format_name(v, "cache_v_l%d", i);
+    ggml_format_name(cross_k, "cache_cross_k_l%d", i);
+    ggml_format_name(cross_v, "cache_cross_v_l%d", i);
+    cache->k_l.push_back(k);
+    cache->v_l.push_back(v);
+    cache->cross_k_l.push_back(cross_k);
+    cache->cross_v_l.push_back(cross_v);
+  }
+
+  // allocate tensors and initialize the buffers to avoid NaNs in the padding
+  ggml_backend_buffer_t buf =
+      ggml_backend_alloc_ctx_tensors_from_buft(cache->ctx, buft);
+  if (!buf) {
+    return false;
+  }
+  ggml_backend_buffer_clear(buf, 0);
+  cache->buf = buf;
+
+  return true;
+}
+
+static struct ggml_tensor *build_dia_decoder_inp_embd(struct ggml_context *ctx,
+                                                      dia_context *dctx,
+                                                      dia_decoder *decoder,
+                                                      dia_ubatch &batch,
+                                                      uint32_t n_output_heads) {
+  struct ggml_tensor *input_embs;
+
+  dctx->audio_inp_tokens =
+      ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_output_heads * 2);
+  ggml_set_input(dctx->audio_inp_tokens);
+  for (int i = 0; i < n_output_heads; i++) {
+    struct ggml_tensor *view =
+        ggml_view_1d(ctx, dctx->audio_inp_tokens, 2,
+                     i * ggml_element_size(dctx->audio_inp_tokens));
+    view->nb[0] = n_output_heads * ggml_element_size(dctx->audio_inp_tokens);
+    if (i == 0) {
+      input_embs = ggml_get_rows(ctx, decoder->embds[i], view);
     } else {
-        buft = ggml_backend_cpu_buffer_type();
+      input_embs = ggml_add(ctx, ggml_get_rows(ctx, decoder->embds[i], view),
+                            input_embs);
     }
-
-    struct ggml_init_params params = {
-        /*.mem_size   =*/ (4u * model->n_decoder_layers + 1) * ggml_tensor_overhead(),
-        /*.mem_buffer =*/ NULL,
-        /*.no_alloc   =*/ true,
-    };
-    ggml_context * ctx = ggml_init(params);
-    if (!ctx) {
-        return false;
-    }
-    cache->ctx = ctx;
-
-    cache->k_l.reserve(model->n_decoder_layers);
-    cache->v_l.reserve(model->n_decoder_layers);
-    cache->cross_k_l.reserve(model->n_decoder_layers);
-    cache->cross_v_l.reserve(model->n_decoder_layers);
-
-    for (int i = 0; i < (int) model->n_decoder_layers; i++) {
-        struct ggml_tensor * k = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_generation_size * 2);
-        struct ggml_tensor * v = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_generation_size * 2);
-        struct ggml_tensor * cross_k = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_encoder_context_length * 2);
-        struct ggml_tensor * cross_v = ggml_new_tensor_1d(cache->ctx, cache->tensor_type, model->head_size * model->decoder_attn_heads * model->max_encoder_context_length * 2);
-        ggml_format_name(k, "cache_k_l%d", i);
-        ggml_format_name(v, "cache_v_l%d", i);
-        ggml_format_name(cross_k, "cache_cross_k_l%d", i);
-        ggml_format_name(cross_v, "cache_cross_v_l%d", i);
-        cache->k_l.push_back(k);
-        cache->v_l.push_back(v);
-        cache->cross_k_l.push_back(cross_k);
-        cache->cross_v_l.push_back(cross_v);
-    }
-
-    // allocate tensors and initialize the buffers to avoid NaNs in the padding
-    ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(cache->ctx, buft);
-    if (!buf) {
-        return false;
-    }
-    ggml_backend_buffer_clear(buf, 0);
-    cache->buf = buf;
-
-    return true;
+  }
+  return input_embs;
 }
 
-static struct ggml_tensor * build_dia_decoder_inp_embd(struct ggml_context * ctx, dia_context *dctx, dia_decoder * decoder, dia_ubatch & batch, uint32_t n_output_heads) {
-    struct ggml_tensor * input_embs;
-
-    dctx->audio_inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_output_heads * 2);
-    ggml_set_input(dctx->audio_inp_tokens);
-    for (int i = 0; i < n_output_heads; i++) {
-        struct ggml_tensor * view = ggml_view_1d(ctx, dctx->audio_inp_tokens, 2, i * ggml_element_size(dctx->audio_inp_tokens));
-        view->nb[0] = n_output_heads * ggml_element_size(dctx->audio_inp_tokens);
-        if (i == 0) {
-            input_embs = ggml_get_rows(ctx, decoder->embds[i], view);
-        } else {
-            input_embs = ggml_add(ctx, ggml_get_rows(ctx, decoder->embds[i], view), input_embs);
-        }
-    }
-    return input_embs;
+static struct ggml_tensor *dia_layer_norm(struct ggml_context *ctx,
+                                          struct ggml_tensor *inputs,
+                                          struct ggml_tensor *weight) {
+  // dia always uses 1e-5 as the default eps
+  float eps = 0.00001;
+  inputs = ggml_rms_norm(ctx, inputs, eps);
+  return ggml_mul(ctx, inputs, weight);
 }
 
-static struct ggml_tensor * dia_layer_norm(struct ggml_context * ctx, struct ggml_tensor * inputs, struct ggml_tensor * weight) {
-    // dia always uses 1e-5 as the default eps
-    float eps = 0.00001;
-    inputs = ggml_rms_norm(ctx, inputs, eps);
-    return ggml_mul(ctx, inputs, weight);
+static struct ggml_tensor *build_dia_encoder_attn_mask(ggml_context *ctx,
+                                                       struct dia_context *dctx,
+                                                       dia_model *model) {
+  dctx->encode_attn_mask = ggml_new_tensor_2d(
+      ctx, GGML_TYPE_F32, (int64_t)model->max_encoder_context_length,
+      (int64_t)model->max_encoder_context_length);
+  ggml_set_input(dctx->encode_attn_mask);
+
+  return dctx->encode_attn_mask;
 }
 
-static struct ggml_tensor * build_dia_encoder_attn_mask(ggml_context * ctx, struct dia_context * dctx, dia_model * model) {
-    dctx->encode_attn_mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, (int64_t) model->max_encoder_context_length, (int64_t) model->max_encoder_context_length);
-    ggml_set_input(dctx->encode_attn_mask);
-
-    return dctx->encode_attn_mask;
+static struct ggml_tensor *build_dia_head_outputs(struct ggml_context *ctx,
+                                                  dia_model *model,
+                                                  struct ggml_tensor *cur) {
+  // going to cat the heads together and then reshape them
+  struct ggml_tensor *out;
+  for (int i = 0; i < model->n_output_heads; i++) {
+    if (i == 0) {
+      out = ggml_mul_mat(ctx, model->decoder->heads[i], cur);
+    } else {
+      out = ggml_concat(ctx, out,
+                        ggml_mul_mat(ctx, model->decoder->heads[i], cur), 2);
+    }
+  }
+  struct ggml_tensor *cond = ggml_cont(
+      ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2], 0));
+  struct ggml_tensor *uncond =
+      ggml_cont(ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2],
+                                  out->nb[1]));
+  return ggml_map_custom2(ctx, cond, uncond, &cfg_scale, out->ne[0],
+                          &model->cfg_scale_data);
 }
 
-static struct ggml_tensor * build_dia_head_outputs(struct ggml_context * ctx, dia_model * model, struct ggml_tensor * cur) {
-    // going to cat the heads together and then reshape them
-    struct ggml_tensor * out;
-    for (int i = 0; i < model->n_output_heads; i++) {
-        if (i == 0) {
-            out = ggml_mul_mat(ctx, model->decoder->heads[i], cur);
-        } else {
-            out = ggml_concat(ctx, out, ggml_mul_mat(ctx, model->decoder->heads[i], cur), 2);
-        }
+static struct ggml_tensor *build_dia_encoder(ggml_context *ctx,
+                                             dia_model *model,
+                                             dia_context *dctx,
+                                             dia_ubatch &batch) {
+  dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32,
+                                        model->max_encoder_context_length * 2);
+  ggml_set_input(dctx->inp_tokens);
+
+  dctx->encode_positions =
+      ggml_new_tensor_1d(ctx, GGML_TYPE_I32, model->max_encoder_context_length);
+  ggml_set_input(dctx->encode_positions);
+
+  struct ggml_tensor *attn_mask = build_dia_encoder_attn_mask(ctx, dctx, model);
+
+  struct ggml_tensor *cur = ggml_reshape_3d(
+      ctx, ggml_get_rows(ctx, model->encoder->embedding, dctx->inp_tokens),
+      model->encoder_hidden_size, model->max_encoder_context_length, 2);
+  for (auto layer : model->encoder->layers) {
+    struct ggml_tensor *residual = cur;
+
+    cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
+    // self-attention
+    {
+      struct ggml_tensor *Qcur = ggml_mul_mat(ctx, layer->q, cur);
+      struct ggml_tensor *Kcur = ggml_mul_mat(ctx, layer->k, cur);
+      struct ggml_tensor *Vcur = ggml_mul_mat(ctx, layer->v, cur);
+
+      // Strangely Dia follows the neoX Rotary Positional Embeddings Protocol
+      Qcur = ggml_rope(
+          ctx,
+          ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size,
+                                         model->encoder_attn_heads,
+                                         model->max_encoder_context_length, 2)),
+          dctx->encode_positions, model->head_size, 2);
+      Kcur = ggml_rope(
+          ctx,
+          ggml_cont(ctx, ggml_reshape_4d(ctx, Kcur, model->head_size,
+                                         model->encoder_attn_heads,
+                                         model->max_encoder_context_length, 2)),
+          dctx->encode_positions, model->head_size, 2);
+      struct ggml_tensor *q =
+          ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
+      struct ggml_tensor *k =
+          ggml_cont(ctx, ggml_permute(ctx, Kcur, 0, 2, 1, 3));
+      struct ggml_tensor *kq = ggml_mul_mat(ctx, k, q);
+      kq = ggml_soft_max_ext(ctx, kq, attn_mask, 1.0f, 0.0f);
+      struct ggml_tensor *v = ggml_cont_4d(
+          ctx, ggml_transpose(ctx, Vcur), model->max_encoder_context_length,
+          model->head_size, model->encoder_attn_heads, 2);
+      struct ggml_tensor *kqv = ggml_mul_mat(ctx, kq, v);
+      struct ggml_tensor *kqv_merged = ggml_permute(ctx, kqv, 2, 0, 1, 3);
+
+      // It is unclear why the attention ops in Dia's encoder don't project to
+      // the embedding dimension size as is standard. Instead they up project to
+      // the decoder's embedding dimension then down project back the the
+      // encoder embedding dimension.
+      cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size,
+                         model->max_encoder_context_length, 2);
+      cur = ggml_mul_mat(ctx, layer->o, cur);
     }
-    struct ggml_tensor * cond = ggml_cont(ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2], 0));
-    struct ggml_tensor * uncond = ggml_cont(ctx, ggml_view_2d(ctx, out, out->ne[0], out->ne[2], out->nb[2], out->nb[1]));
-    return ggml_map_custom2(ctx, cond, uncond, &cfg_scale, out->ne[0], &model->cfg_scale_data);
+
+    cur = ggml_add(ctx, cur, residual);
+    struct ggml_tensor *residual_mlp = cur;
+
+    cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
+    // mlp
+    {
+      cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)),
+                     ggml_mul_mat(ctx, layer->up, cur));
+      cur = ggml_mul_mat(ctx, layer->out, cur);
+    }
+
+    cur = ggml_add(ctx, cur, residual_mlp);
+  }
+
+  cur = dia_layer_norm(ctx, cur, model->encoder->norm);
+  return cur;
 }
 
-static struct ggml_tensor * build_dia_encoder(ggml_context * ctx, dia_model * model, dia_context * dctx, dia_ubatch & batch) {
-    dctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, model->max_encoder_context_length*2);
-    ggml_set_input(dctx->inp_tokens);
-
-    dctx->encode_positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, model->max_encoder_context_length);
-    ggml_set_input(dctx->encode_positions);
-
-    struct ggml_tensor * attn_mask = build_dia_encoder_attn_mask(ctx, dctx, model);
-
-    struct ggml_tensor * cur = ggml_reshape_3d(ctx, ggml_get_rows(ctx, model->encoder->embedding, dctx->inp_tokens), model->encoder_hidden_size, model->max_encoder_context_length, 2);
-    for (auto layer : model->encoder->layers) {
-        struct ggml_tensor * residual = cur;
-        
-        cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
-        // self-attention
-        {
-            struct ggml_tensor * Qcur = ggml_mul_mat(ctx, layer->q, cur);
-            struct ggml_tensor * Kcur = ggml_mul_mat(ctx, layer->k, cur);
-            struct ggml_tensor * Vcur = ggml_mul_mat(ctx, layer->v, cur);
-
-            // Strangely Dia follows the neoX Rotary Positional Embeddings Protocol
-            Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size, model->encoder_attn_heads, model->max_encoder_context_length, 2)), dctx->encode_positions, model->head_size, 2);
-            Kcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Kcur, model->head_size, model->encoder_attn_heads, model->max_encoder_context_length, 2)), dctx->encode_positions, model->head_size, 2);
-            struct ggml_tensor * q = ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
-            struct ggml_tensor * k = ggml_cont(ctx, ggml_permute(ctx, Kcur, 0, 2, 1, 3));
-            struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
-            kq = ggml_soft_max_ext(ctx, kq, attn_mask, 1.0f, 0.0f);
-            struct ggml_tensor * v = ggml_cont_4d(ctx, ggml_transpose(ctx, Vcur), model->max_encoder_context_length, model->head_size, model->encoder_attn_heads, 2);
-            struct ggml_tensor * kqv = ggml_mul_mat(ctx, kq, v);
-            struct ggml_tensor * kqv_merged = ggml_permute(ctx, kqv, 2, 0, 1, 3);
-
-            // It is unclear why the attention ops in Dia's encoder don't project to the embedding dimension size as is standard. Instead they up project to the decoder's embedding dimension
-            // then down project back the the encoder embedding dimension. 
-            cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size, model->max_encoder_context_length, 2);
-            cur = ggml_mul_mat(ctx, layer->o, cur);
-        }
-
-        cur = ggml_add(ctx, cur, residual);
-        struct ggml_tensor * residual_mlp = cur;
-
-        cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
-        // mlp
-        {
-            cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)), ggml_mul_mat(ctx, layer->up, cur));
-            cur = ggml_mul_mat(ctx, layer->out, cur);
-        }
-
-        cur = ggml_add(ctx, cur, residual_mlp);
+static struct ggml_tensor *
+repeat_interleave_dim1(ggml_context *ctx, struct ggml_tensor *a, int repeat) {
+  // return ggml_repeat(ctx, a, ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0],
+  // 4*a->ne[1], a->ne[2], a->ne[3]));
+  struct ggml_tensor *running;
+  for (int i = 0; i < a->ne[1]; i++) {
+    int offset = i * a->nb[1];
+    struct ggml_tensor *t =
+        ggml_cont(ctx, ggml_view_4d(ctx, a, a->ne[0], 1, a->ne[2], a->ne[3],
+                                    a->nb[1], a->nb[2], a->nb[3], offset));
+    t = ggml_repeat(ctx, t,
+                    ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], repeat,
+                                       a->ne[2], a->ne[3]));
+    if (i == 0) {
+      running = t;
+    } else {
+      running = ggml_concat(ctx, running, t, 1);
     }
-
-    cur = dia_layer_norm(ctx, cur, model->encoder->norm);
-    return cur;
+  }
+  return running;
 }
 
-static struct ggml_tensor * repeat_interleave_dim1(ggml_context * ctx, struct ggml_tensor * a, int repeat) {
-    //return ggml_repeat(ctx, a, ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], 4*a->ne[1], a->ne[2], a->ne[3]));
-    struct ggml_tensor * running;
-    for (int i = 0; i < a->ne[1]; i++) {
-        int offset = i * a->nb[1];
-        struct ggml_tensor * t = ggml_cont(ctx, ggml_view_4d(ctx, a, a->ne[0], 1, a->ne[2], a->ne[3], a->nb[1], a->nb[2], a->nb[3], offset));
-        t = ggml_repeat(ctx, t, ggml_new_tensor_4d(ctx, GGML_TYPE_F32, a->ne[0], repeat, a->ne[2], a->ne[3]));
-        if (i == 0) {
-            running = t;
-        } else {
-            running = ggml_concat(ctx, running, t, 1);
-        }
-    }
-    return running;
+static void build_dia_self_kv_store(ggml_context *ctx, dia_context *dctx,
+                                    dia_model *model, dia_kv_cache *kv,
+                                    ggml_cgraph *gf, struct ggml_tensor *k,
+                                    struct ggml_tensor *v, dia_ubatch &batch,
+                                    int layer_index) {
+  int64_t attn_size = model->head_size * model->decoder_attn_heads;
+
+  struct ggml_tensor *k_cache_view =
+      ggml_view_2d(ctx, kv->k_l[layer_index], attn_size, 2,
+                   attn_size * model->max_generation_size *
+                       ggml_element_size(kv->k_l[layer_index]),
+                   attn_size * dctx->current_position *
+                       ggml_element_size(kv->k_l[layer_index]));
+
+  k = ggml_rope(ctx,
+                ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size,
+                                               model->decoder_attn_heads /
+                                                   model->decoder_query_heads,
+                                               batch.sequence_length, 2)),
+                dctx->positions, model->head_size, 2);
+  // Since the sequence length should always be 1 here this is the most
+  // pertinent time to repeat the heads for grouped query attention. If GGML
+  // supported a repeat_interleave op then it would be more optimal to store
+  // just the groups in the cache and interleave the attention heads after
+  // recalling from the cache
+  k = repeat_interleave_dim1(
+      ctx,
+      ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size,
+                                     model->decoder_attn_heads /
+                                         model->decoder_query_heads,
+                                     batch.sequence_length, 2)),
+      model->decoder_query_heads);
+  k = ggml_cont(ctx, ggml_reshape_2d(ctx, k, attn_size, 2));
+
+  ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
+
+  struct ggml_tensor *v_cache_view = nullptr;
+
+  v_cache_view = ggml_view_2d(ctx, kv->v_l[layer_index], attn_size, 2,
+                              attn_size * model->max_generation_size *
+                                  ggml_element_size(kv->v_l[layer_index]),
+                              attn_size * dctx->current_position *
+                                  ggml_element_size(kv->v_l[layer_index]));
+
+  // Since the sequence length should always be 1 here this is the most
+  // pertinent time to repeat the heads for grouped query attention. If GGML
+  // supported a repeat_interleave op then it would be more optimal to store
+  // just the groups in the cache and interleave the attention heads after
+  // recalling from the cache
+  v = repeat_interleave_dim1(
+      ctx,
+      ggml_cont(ctx, ggml_reshape_4d(ctx, v, model->head_size,
+                                     model->decoder_attn_heads /
+                                         model->decoder_query_heads,
+                                     batch.sequence_length, 2)),
+      model->decoder_query_heads);
+
+  ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
 }
 
-static void build_dia_self_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * k, struct ggml_tensor * v, dia_ubatch & batch, int layer_index) {
-    int64_t attn_size = model->head_size * model->decoder_attn_heads;
+static void build_dia_cross_kv_store(ggml_context *ctx, dia_context *dctx,
+                                     dia_model *model, dia_kv_cache *kv,
+                                     ggml_cgraph *gf,
+                                     struct ggml_tensor *encoder_hidden_states,
+                                     int layer_index) {
+  dia_decoder_layer *layer = model->decoder->layers[layer_index];
+  struct ggml_tensor *encoder_states_key_view = ggml_cont(
+      ctx,
+      ggml_view_3d(
+          ctx, encoder_hidden_states, model->encoder_hidden_size,
+          dctx->prompt_size, 2,
+          model->encoder_hidden_size * ggml_element_size(encoder_hidden_states),
+          model->encoder_hidden_size * model->max_encoder_context_length *
+              ggml_element_size(encoder_hidden_states),
+          0));
 
-    struct ggml_tensor * k_cache_view = 
-        ggml_view_2d(
-                ctx, kv->k_l[layer_index], attn_size, 2, 
-                attn_size * model->max_generation_size * ggml_element_size(kv->k_l[layer_index]), 
-                attn_size*dctx->current_position*ggml_element_size(kv->k_l[layer_index]));
+  struct ggml_tensor *k =
+      ggml_mul_mat(ctx, layer->cross_attn_k, encoder_states_key_view);
+  struct ggml_tensor *positions_view =
+      ggml_view_1d(ctx, dctx->encode_positions, dctx->prompt_size, 0);
 
-    k = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
-    // Since the sequence length should always be 1 here this is the most pertinent time to repeat the heads for grouped query attention.
-    // If GGML supported a repeat_interleave op then it would be more optimal to store just the groups in the cache and interleave the attention heads after recalling
-    // from the cache
-    k = repeat_interleave_dim1(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), model->decoder_query_heads);
-    k = ggml_cont(ctx, ggml_reshape_2d(ctx, k, attn_size, 2));
+  k = ggml_rope(ctx,
+                ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size,
+                                               model->decoder_attn_heads,
+                                               dctx->prompt_size, 2)),
+                positions_view, model->head_size, 2);
+  k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 1, 3, 2));
 
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
+  struct ggml_tensor *k_cache_view = ggml_view_4d(
+      ctx, kv->cross_k_l[layer_index], model->head_size,
+      model->decoder_attn_heads, 2, dctx->prompt_size,
+      model->head_size * ggml_element_size(kv->cross_k_l[layer_index]),
+      model->head_size * model->decoder_attn_heads *
+          ggml_element_size(kv->cross_k_l[layer_index]),
+      model->head_size * model->decoder_attn_heads * 2 *
+          ggml_element_size(kv->cross_k_l[layer_index]),
+      0);
 
-    struct ggml_tensor * v_cache_view = nullptr;
+  ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
 
-    v_cache_view = ggml_view_2d(
-            ctx, kv->v_l[layer_index], attn_size, 2, 
-            attn_size * model->max_generation_size * ggml_element_size(kv->v_l[layer_index]), 
-            attn_size*dctx->current_position*ggml_element_size(kv->v_l[layer_index]));
+  struct ggml_tensor *v =
+      ggml_cont(ctx, ggml_transpose(ctx, ggml_mul_mat(ctx, layer->cross_attn_v,
+                                                      encoder_hidden_states)));
+  v = ggml_cont_4d(ctx, v, model->max_encoder_context_length, model->head_size,
+                   model->decoder_attn_heads, 2);
 
-    // Since the sequence length should always be 1 here this is the most pertinent time to repeat the heads for grouped query attention.
-    // If GGML supported a repeat_interleave op then it would be more optimal to store just the groups in the cache and interleave the attention heads after recalling
-    // from the cache
-    v = repeat_interleave_dim1(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, v, model->head_size, model->decoder_attn_heads / model->decoder_query_heads, batch.sequence_length, 2)), model->decoder_query_heads);
+  struct ggml_tensor *v_cache_view = ggml_view_4d(
+      ctx, kv->cross_v_l[layer_index], model->max_encoder_context_length,
+      model->head_size, model->decoder_attn_heads, 2,
+      model->max_encoder_context_length *
+          ggml_element_size(kv->cross_v_l[layer_index]),
+      model->head_size * model->max_encoder_context_length *
+          ggml_element_size(kv->cross_v_l[layer_index]),
+      model->head_size * model->max_encoder_context_length *
+          model->decoder_attn_heads *
+          ggml_element_size(kv->cross_v_l[layer_index]),
+      0);
 
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
+  ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
 }
 
-static void build_dia_cross_kv_store(ggml_context * ctx, dia_context * dctx, dia_model * model, dia_kv_cache * kv, ggml_cgraph * gf, struct ggml_tensor * encoder_hidden_states, int layer_index) {
-    dia_decoder_layer * layer = model->decoder->layers[layer_index];
-    struct ggml_tensor * encoder_states_key_view = ggml_cont(ctx, ggml_view_3d(
-        ctx, 
-        encoder_hidden_states, 
-        model->encoder_hidden_size, 
-        dctx->prompt_size, 
-        2, 
-        model->encoder_hidden_size * ggml_element_size(encoder_hidden_states), model->encoder_hidden_size * model->max_encoder_context_length * ggml_element_size(encoder_hidden_states), 0));
+static struct ggml_tensor *
+build_dia_decoder(ggml_cgraph *gf, ggml_context *ctx, dia_model *model,
+                  dia_context *dctx, dia_kv_cache *cache, dia_ubatch &batch,
+                  struct ggml_tensor *encoder_hidden_states) {
+  dctx->positions =
+      ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length);
+  ggml_set_input(dctx->positions);
+  struct ggml_tensor *cur = build_dia_decoder_inp_embd(
+      ctx, dctx, model->decoder, batch, model->n_output_heads);
 
-    struct ggml_tensor * k = ggml_mul_mat(ctx, layer->cross_attn_k, encoder_states_key_view);
-    struct ggml_tensor * positions_view = ggml_view_1d(ctx, dctx->encode_positions, dctx->prompt_size, 0);
+  for (int l = 0; l < model->decoder->layers.size(); l++) {
+    dia_decoder_layer *layer = model->decoder->layers[l];
+    struct ggml_tensor *residual = cur;
 
-    k = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, k, model->head_size, model->decoder_attn_heads, dctx->prompt_size, 2)), positions_view, model->head_size, 2);
-    k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 1, 3, 2));
+    cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
+    // self-attention
+    {
+      struct ggml_tensor *Qcur = ggml_mul_mat(ctx, layer->self_attn_q, cur);
+      struct ggml_tensor *Kcur = ggml_mul_mat(ctx, layer->self_attn_k, cur);
+      struct ggml_tensor *Vcur = ggml_mul_mat(ctx, layer->self_attn_v, cur);
 
-    struct ggml_tensor * k_cache_view =
-        ggml_view_4d(
-                ctx, kv->cross_k_l[layer_index], model->head_size, model->decoder_attn_heads, 2, dctx->prompt_size, 
-                model->head_size*ggml_element_size(kv->cross_k_l[layer_index]), 
-                model->head_size*model->decoder_attn_heads*ggml_element_size(kv->cross_k_l[layer_index]),
-                model->head_size*model->decoder_attn_heads*2*ggml_element_size(kv->cross_k_l[layer_index]),
-                0);
+      build_dia_self_kv_store(ctx, dctx, model, cache, gf, Kcur, Vcur, batch,
+                              l);
+      struct ggml_tensor *k = ggml_view_4d(
+          ctx, cache->k_l[l], model->head_size, model->decoder_attn_heads,
+          dctx->current_position + 1, 2,
+          ggml_element_size(cache->k_l[l]) * model->head_size,
+          ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads *
+              model->head_size,
+          ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads *
+              model->head_size * model->max_generation_size,
+          0);
+      k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 2, 1, 3));
 
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, k, k_cache_view));
+      struct ggml_tensor *v = ggml_view_3d(
+          ctx, cache->v_l[l], model->head_size * model->decoder_attn_heads,
+          dctx->current_position + 1, 2,
+          ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads *
+              model->head_size,
+          ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads *
+              model->head_size * model->max_generation_size,
+          0);
+      v = ggml_cont_4d(ctx, ggml_transpose(ctx, v), dctx->current_position + 1,
+                       model->head_size, model->decoder_attn_heads, 2);
 
-    struct ggml_tensor * v = ggml_cont(ctx, ggml_transpose(ctx, ggml_mul_mat(ctx, layer->cross_attn_v, encoder_hidden_states)));
-    v = ggml_cont_4d(ctx, v, model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2);
+      // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
+      Qcur =
+          ggml_rope(ctx,
+                    ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size,
+                                                   model->decoder_attn_heads,
+                                                   batch.sequence_length, 2)),
+                    dctx->positions, model->head_size, 2);
+      struct ggml_tensor *q =
+          ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
+      struct ggml_tensor *kq = ggml_mul_mat(ctx, ggml_cont(ctx, k), q);
 
-    struct ggml_tensor * v_cache_view =
-        ggml_view_4d(
-                ctx, kv->cross_v_l[layer_index], model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2, 
-                model->max_encoder_context_length*ggml_element_size(kv->cross_v_l[layer_index]), 
-                model->head_size*model->max_encoder_context_length*ggml_element_size(kv->cross_v_l[layer_index]), 
-                model->head_size*model->max_encoder_context_length*model->decoder_attn_heads*ggml_element_size(kv->cross_v_l[layer_index]), 
-                0);
+      // given that attention bias, scaling and masking are not used for
+      // decoding, it might be faster to prefer the #ggml_soft_max op here,
+      kq = ggml_soft_max_ext(ctx, kq, nullptr, 1.0f, 0.0f);
+      struct ggml_tensor *kqv = ggml_mul_mat(ctx, kq, v);
+      struct ggml_tensor *kqv_merged =
+          ggml_cont(ctx, ggml_permute(ctx, kqv, 2, 0, 1, 3));
+      cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size,
+                         batch.sequence_length, 2);
+      cur = ggml_mul_mat(ctx, layer->self_attn_o, cur);
+    }
 
-    ggml_build_forward_expand(gf, ggml_cpy(ctx, v, v_cache_view));
+    // if we ever need to support multiple step decoder runs then this reshape
+    // will need to be replaced with permutation.
+    cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
+    cur = ggml_add(ctx, cur, residual);
+    struct ggml_tensor *residual_cross = cur;
+
+    cur = dia_layer_norm(ctx, cur, layer->cross_attn_norm);
+    // cross-attention
+    {
+      struct ggml_tensor *cross_Qcur =
+          ggml_mul_mat(ctx, layer->cross_attn_q, cur);
+
+      // only load the cross attention kv store when performing the encoding
+      // step
+      if (batch.encoder_step) {
+        build_dia_cross_kv_store(ctx, dctx, model, cache, gf,
+                                 encoder_hidden_states, l);
+      }
+
+      struct ggml_tensor *cross_k = ggml_view_4d(
+          ctx, cache->cross_k_l[l], model->head_size, model->decoder_attn_heads,
+          2, model->max_encoder_context_length,
+          model->head_size * ggml_element_size(cache->cross_k_l[l]),
+          model->head_size * model->decoder_attn_heads *
+              ggml_element_size(cache->cross_k_l[l]),
+          model->head_size * model->decoder_attn_heads * 2 *
+              ggml_element_size(cache->cross_k_l[l]),
+          0);
+      // the double permute operation shouldn't be necessary here, but it seems
+      // that currently ggml permute only currently alows for a single axis pair
+      // to be transposed.
+      cross_k = ggml_cont(
+          ctx, ggml_permute(ctx, ggml_permute(ctx, cross_k, 0, 1, 3, 2), 0, 2,
+                            1, 3));
+
+      struct ggml_tensor *cross_v = ggml_cont(
+          ctx, ggml_view_4d(
+                   ctx, cache->cross_v_l[l], model->max_encoder_context_length,
+                   model->head_size, model->decoder_attn_heads, 2,
+                   model->max_encoder_context_length *
+                       ggml_element_size(cache->cross_v_l[l]),
+                   model->head_size * model->max_encoder_context_length *
+                       ggml_element_size(cache->cross_v_l[l]),
+                   model->head_size * model->max_encoder_context_length *
+                       model->decoder_attn_heads *
+                       ggml_element_size(cache->cross_v_l[l]),
+                   0));
+
+      // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
+      cross_Qcur = ggml_rope(
+          ctx,
+          ggml_cont(ctx, ggml_reshape_4d(ctx, cross_Qcur, model->head_size,
+                                         model->decoder_attn_heads,
+                                         batch.sequence_length, 2)),
+          dctx->positions, model->head_size, 2);
+      struct ggml_tensor *cross_q =
+          ggml_cont(ctx, ggml_permute(ctx, cross_Qcur, 0, 2, 1, 3));
+      struct ggml_tensor *cross_kq = ggml_mul_mat(ctx, cross_k, cross_q);
+
+      // given that attention bias, scaling and masking are not used for
+      // decoding, it might be faster to prefer the #ggml_soft_max op here,
+      cross_kq = ggml_soft_max_ext(ctx, cross_kq, nullptr, 1.0f, 0.0f);
+      struct ggml_tensor *cross_kqv = ggml_mul_mat(ctx, cross_kq, cross_v);
+      struct ggml_tensor *cross_kqv_merged =
+          ggml_cont(ctx, ggml_permute(ctx, cross_kqv, 2, 0, 1, 3));
+      cur = ggml_cont_3d(ctx, cross_kqv_merged, model->decoder_hidden_size,
+                         batch.sequence_length, 2);
+      cur = ggml_mul_mat(ctx, layer->cross_attn_o, cur);
+    }
+
+    // if we ever need to support multiple step decoder runs then this reshape
+    // will need to be replaced with permutation.
+    cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
+    cur = ggml_add(ctx, cur, residual_cross);
+    struct ggml_tensor *residual_mlp = cur;
+
+    cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
+    // mlp
+    {
+      cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)),
+                     ggml_mul_mat(ctx, layer->up, cur));
+      cur = ggml_mul_mat(ctx, layer->out, cur);
+    }
+
+    cur = ggml_add(ctx, cur, residual_mlp);
+  }
+
+  cur = dia_layer_norm(ctx, cur, model->decoder->norm);
+  cur = build_dia_head_outputs(ctx, model, cur);
+  return cur;
 }
 
-static struct ggml_tensor * build_dia_decoder(
-        ggml_cgraph * gf,
-        ggml_context * ctx, 
-        dia_model * model, 
-        dia_context * dctx, 
-        dia_kv_cache * cache, 
-        dia_ubatch & batch, 
-        struct ggml_tensor * encoder_hidden_states) {
-    dctx->positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.sequence_length);
-    ggml_set_input(dctx->positions);
-    struct ggml_tensor * cur = build_dia_decoder_inp_embd(ctx, dctx, model->decoder, batch, model->n_output_heads);
+void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch &batch) {
+  // Dia's tokenization process is unusual. Essentially Dia takes the byte value
+  // for each character and uses that as a token array. Additionally, because
+  // Dia performs a cfg-scale adjustment before sampling tokens, it is necessary
+  // to generate with a conditioned context (i.e. with the text) and an
+  // unconditioned context (i.e. without any text) so that proper adjustments
+  // can be perfored at each generation step. This means that we need to pad the
+  // end of our tokens to the max context size for both the conditional and
+  // unconditional sequence.
 
-    for (int l = 0; l < model->decoder->layers.size(); l++){
-        dia_decoder_layer * layer = model->decoder->layers[l];
-        struct ggml_tensor * residual = cur;
-        
-        cur = dia_layer_norm(ctx, cur, layer->self_attn_norm);
-        // self-attention
-        {
-            struct ggml_tensor * Qcur = ggml_mul_mat(ctx, layer->self_attn_q, cur);
-            struct ggml_tensor * Kcur = ggml_mul_mat(ctx, layer->self_attn_k, cur);
-            struct ggml_tensor * Vcur = ggml_mul_mat(ctx, layer->self_attn_v, cur);
+  // if the sentence isn't prepended by dialogue start tokens, [S1] or [S2],
+  // then append one.
+  sentence = strip(sentence);
+  std::string start = sentence.substr(0, 4);
+  if (start != "[S1]" && start != "[S2]") {
+    sentence = "[S1] " + sentence;
+  }
+  if (sentence[sentence.size() - 1] != '.') {
+    sentence += ".";
+  }
 
-            build_dia_self_kv_store(ctx, dctx, model, cache, gf, Kcur, Vcur, batch, l);
-            struct ggml_tensor * k =
-                ggml_view_4d(ctx, cache->k_l[l],
-                        model->head_size, model->decoder_attn_heads, dctx->current_position + 1, 2,
-                        ggml_element_size(cache->k_l[l]) * model->head_size,
-                        ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads * model->head_size,
-                        ggml_element_size(cache->k_l[l]) * model->decoder_attn_heads * model->head_size * model->max_generation_size,
-                        0);
-            k = ggml_cont(ctx, ggml_permute(ctx, k, 0, 2, 1, 3));
+  // [S1] and [S2] are special character sequences that are replaced with the
+  // special tokens 0x01 and 0x02 respectively.
+  std::string r1(1, 1);
+  std::string r2(1, 2);
+  while (sentence.find("[S1]") != std::string::npos) {
+    size_t pos = sentence.find("[S1]");
+    sentence.replace(pos, 4, r1);
+  }
+  while (sentence.find("[S2]") != std::string::npos) {
+    size_t pos = sentence.find("[S2]");
+    sentence.replace(pos, 4, r2);
+  }
 
-            struct ggml_tensor * v = 
-                ggml_view_3d(ctx, cache->v_l[l],
-                        model->head_size * model->decoder_attn_heads, dctx->current_position + 1, 2,
-                        ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads * model->head_size,
-                        ggml_element_size(cache->v_l[l]) * model->decoder_attn_heads * model->head_size * model->max_generation_size,
-                        0);
-            v = ggml_cont_4d(ctx, ggml_transpose(ctx, v), dctx->current_position + 1, model->head_size, model->decoder_attn_heads, 2); 
+  if (sentence.size() > model->max_encoder_context_length) {
+    TTS_ABORT("Dia currently only supports a max of %d characters and received "
+              "an input of %d characters.",
+              model->max_encoder_context_length, sentence.size());
+  }
+  batch.tokens.reserve(model->max_encoder_context_length * 2);
+  for (auto character : sentence) {
+    batch.tokens.push_back((uint32_t)character);
+  }
+  batch.sentence_length = batch.tokens.size();
+  // this 100 token warning is arbitrarily chosen based on spot checking small
+  // prompt performance
+  if (batch.sentence_length <= 100) {
+    fprintf(stdout, "Your prompt has fewer than 100 tokens. Please note that "
+                    "Dia's generation with prompts that are fewer than 100 "
+                    "tokens is highly inconsistent.\n");
+  }
 
-            // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
-            Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, Qcur, model->head_size, model->decoder_attn_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
-            struct ggml_tensor * q = ggml_cont(ctx, ggml_permute(ctx, Qcur, 0, 2, 1, 3));
-            struct ggml_tensor * kq = ggml_mul_mat(ctx, ggml_cont(ctx, k), q);
-
-            // given that attention bias, scaling and masking are not used for decoding, it might be faster to prefer the #ggml_soft_max op here,
-            kq = ggml_soft_max_ext(ctx, kq, nullptr, 1.0f, 0.0f);
-            struct ggml_tensor * kqv = ggml_mul_mat(ctx, kq, v);
-            struct ggml_tensor * kqv_merged = ggml_cont(ctx, ggml_permute(ctx, kqv, 2, 0, 1, 3));
-            cur = ggml_cont_3d(ctx, kqv_merged, model->decoder_hidden_size, batch.sequence_length, 2);
-            cur = ggml_mul_mat(ctx, layer->self_attn_o, cur);
-        }
-
-
-        // if we ever need to support multiple step decoder runs then this reshape will need to be replaced with permutation.
-        cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
-        cur = ggml_add(ctx, cur, residual);
-        struct ggml_tensor * residual_cross = cur;
-
-        cur = dia_layer_norm(ctx, cur, layer->cross_attn_norm);
-        // cross-attention
-        {
-            struct ggml_tensor * cross_Qcur = ggml_mul_mat(ctx, layer->cross_attn_q, cur);
-
-            // only load the cross attention kv store when performing the encoding step
-            if (batch.encoder_step) {
-                build_dia_cross_kv_store(ctx, dctx, model, cache, gf, encoder_hidden_states, l);
-            }
-
-            struct ggml_tensor * cross_k = 
-                ggml_view_4d(
-                        ctx, cache->cross_k_l[l], model->head_size, model->decoder_attn_heads, 2,
-                        model->max_encoder_context_length, model->head_size*ggml_element_size(cache->cross_k_l[l]), 
-                        model->head_size*model->decoder_attn_heads*ggml_element_size(cache->cross_k_l[l]), 
-                        model->head_size*model->decoder_attn_heads*2*ggml_element_size(cache->cross_k_l[l]),                 
-                        0);
-            // the double permute operation shouldn't be necessary here, but it seems that currently ggml permute only currently alows for a single
-            // axis pair to be transposed.
-            cross_k = ggml_cont(ctx, ggml_permute(ctx, ggml_permute(ctx, cross_k, 0, 1, 3, 2), 0, 2, 1, 3));
-
-            struct ggml_tensor * cross_v = 
-                ggml_cont(ctx, ggml_view_4d(
-                        ctx, cache->cross_v_l[l], model->max_encoder_context_length, model->head_size, model->decoder_attn_heads, 2,
-                        model->max_encoder_context_length*ggml_element_size(cache->cross_v_l[l]), 
-                        model->head_size*model->max_encoder_context_length*ggml_element_size(cache->cross_v_l[l]), 
-                        model->head_size*model->max_encoder_context_length*model->decoder_attn_heads*ggml_element_size(cache->cross_v_l[l]),
-                        0));
-
-            // As noted in the encoder Dia uses the Neo-X protocol for RoPE.
-            cross_Qcur = ggml_rope(ctx, ggml_cont(ctx, ggml_reshape_4d(ctx, cross_Qcur, model->head_size, model->decoder_attn_heads, batch.sequence_length, 2)), dctx->positions, model->head_size, 2);
-            struct ggml_tensor * cross_q = ggml_cont(ctx, ggml_permute(ctx, cross_Qcur, 0, 2, 1, 3));
-            struct ggml_tensor * cross_kq = ggml_mul_mat(ctx, cross_k, cross_q);
-
-            // given that attention bias, scaling and masking are not used for decoding, it might be faster to prefer the #ggml_soft_max op here,
-            cross_kq = ggml_soft_max_ext(ctx, cross_kq, nullptr, 1.0f, 0.0f);
-            struct ggml_tensor * cross_kqv = ggml_mul_mat(ctx, cross_kq, cross_v);
-            struct ggml_tensor * cross_kqv_merged = ggml_cont(ctx, ggml_permute(ctx, cross_kqv, 2, 0, 1, 3));
-            cur = ggml_cont_3d(ctx, cross_kqv_merged, model->decoder_hidden_size, batch.sequence_length, 2);
-            cur = ggml_mul_mat(ctx, layer->cross_attn_o, cur);
-        }
-
-
-        // if we ever need to support multiple step decoder runs then this reshape will need to be replaced with permutation.
-        cur = ggml_cont_2d(ctx, cur, cur->ne[0], 2);
-        cur = ggml_add(ctx, cur, residual_cross);
-        struct ggml_tensor * residual_mlp = cur;
-
-        cur = dia_layer_norm(ctx, cur, layer->mlp_norm);
-        // mlp
-        {
-            cur = ggml_mul(ctx, ggml_silu(ctx, ggml_mul_mat(ctx, layer->gate, cur)), ggml_mul_mat(ctx, layer->up, cur));
-            cur = ggml_mul_mat(ctx, layer->out, cur);
-        }
-
-        cur = ggml_add(ctx, cur, residual_mlp);
-    }
-
-    cur = dia_layer_norm(ctx, cur, model->decoder->norm);
-    cur = build_dia_head_outputs(ctx, model, cur);
-    return cur;
+  for (int i = (int)batch.tokens.size();
+       i < model->max_encoder_context_length * 2; i++) {
+    batch.tokens.push_back(0u);
+  }
 }
-
-void dia_runner::tokenize_sentence(std::string sentence, dia_ubatch & batch) {
-    // Dia's tokenization process is unusual. Essentially Dia takes the byte value for each character and uses that as 
-    // a token array. Additionally, because Dia performs a cfg-scale adjustment before sampling tokens, it is necessary to 
-    // generate with a conditioned context (i.e. with the text) and an unconditioned context (i.e. without any text) so that
-    // proper adjustments can be perfored at each generation step. This means that we need to pad the end of our tokens to the 
-    // max context size for both the conditional and unconditional sequence.
-
-    // if the sentence isn't prepended by dialogue start tokens, [S1] or [S2], then append one.
-    sentence = strip(sentence);
-    std::string start = sentence.substr(0, 4);
-    if (start != "[S1]" && start != "[S2]") {
-        sentence = "[S1] " + sentence;
-    }
-    if (sentence[sentence.size() - 1] != '.') {
-        sentence += ".";
-    }
-
-    // [S1] and [S2] are special character sequences that are replaced with the special tokens 0x01 and 0x02 respectively.
-    std::string r1(1, 1);
-    std::string r2(1, 2);
-    while (sentence.find("[S1]") != std::string::npos) {
-        size_t pos = sentence.find("[S1]");
-        sentence.replace(pos, 4, r1);
-    }
-    while (sentence.find("[S2]") != std::string::npos) {
-        size_t pos = sentence.find("[S2]");
-        sentence.replace(pos, 4, r2);
-    }
-
-    if (sentence.size() > model->max_encoder_context_length) {
-        TTS_ABORT("Dia currently only supports a max of %d characters and received an input of %d characters.", model->max_encoder_context_length, sentence.size());
-    }
-    batch.tokens.reserve(model->max_encoder_context_length * 2);
-    for (auto character : sentence) {
-        batch.tokens.push_back((uint32_t) character);
-    }
-    batch.sentence_length = batch.tokens.size();
-    // this 100 token warning is arbitrarily chosen based on spot checking small prompt performance
-    if (batch.sentence_length <= 100) {
-        fprintf(stdout, "Your prompt has fewer than 100 tokens. Please note that Dia's generation with prompts that are fewer than 100 tokens is highly inconsistent.\n");
-    }
-
-    for (int i = (int) batch.tokens.size(); i < model->max_encoder_context_length * 2; i++) {
-        batch.tokens.push_back(0u);
-    }
- }
 
 dia_ubatch dia_runner::batch_from_sentence(std::string sentence) {
-    // if we are generating a new batch from tokens then we need to run the encoder step;
-    struct dia_ubatch batch{ 1, true};
-    tokenize_sentence(sentence, batch);
-    batch.audio_tokens.reserve(model->n_output_heads);
-    for (int i = 0; i < model->n_output_heads; i++) {
-        batch.audio_tokens.push_back(model->bos_token_id);
-    }
-    return batch;
+  // if we are generating a new batch from tokens then we need to run the
+  // encoder step;
+  struct dia_ubatch batch {
+    1, true
+  };
+  tokenize_sentence(sentence, batch);
+  batch.audio_tokens.reserve(model->n_output_heads);
+  for (int i = 0; i < model->n_output_heads; i++) {
+    batch.audio_tokens.push_back(model->bos_token_id);
+  }
+  return batch;
 }
 
 /*
  * There are two unique features of Dia's model architecture:
- * 1.  Dia cleans its output generation by adding the difference between its text based output (its conditional output) and its unconditional output
- *     to the conditional ouput before sampling. This is why the batch is set to two throughout the graph.
+ * 1.  Dia cleans its output generation by adding the difference between its
+ * text based output (its conditional output) and its unconditional output to
+ * the conditional ouput before sampling. This is why the batch is set to two
+ * throughout the graph.
  *
- * 2.  Dia's decoder attends across the entire encoded space including the pad buffer which receives a unique attention mask. This is why the 
- *     encoder sequence is always max length.
+ * 2.  Dia's decoder attends across the entire encoded space including the pad
+ * buffer which receives a unique attention mask. This is why the encoder
+ * sequence is always max length.
  */
-struct ggml_cgraph * dia_runner::build_dia_graph(dia_ubatch & batch) {
-    init_build();
-    struct ggml_cgraph * gf = ggml_new_graph_custom(ctx, 8192, false);
-    struct ggml_tensor * encoded_states = nullptr;
+struct ggml_cgraph *dia_runner::build_dia_graph(dia_ubatch &batch) {
+  init_build();
+  struct ggml_cgraph *gf = ggml_new_graph_custom(ctx, 8192, false);
+  struct ggml_tensor *encoded_states = nullptr;
 
-    if (batch.encoder_step) {
-        encoded_states = build_dia_encoder(ctx, model, dctx, batch);
-        ggml_build_forward_expand(gf, encoded_states);
-    }
+  if (batch.encoder_step) {
+    encoded_states = build_dia_encoder(ctx, model, dctx, batch);
+    ggml_build_forward_expand(gf, encoded_states);
+  }
 
-    struct ggml_tensor * cur = build_dia_decoder(gf, ctx, model, dctx, kv_cross_self, batch, encoded_states);
-    ggml_set_name(cur, "decoder_output");
-    ggml_build_forward_expand(gf, cur);
-    free_build();
-    
-    return gf;
+  struct ggml_tensor *cur = build_dia_decoder(
+      gf, ctx, model, dctx, kv_cross_self, batch, encoded_states);
+  ggml_set_name(cur, "decoder_output");
+  ggml_build_forward_expand(gf, cur);
+  free_build();
+
+  return gf;
 }
 
-void dia_runner::configure_generation(generation_configuration * config) {
-    GGML_ASSERT(config->max_tokens == 0 || config->max_tokens > model->max_delay);
-    decode_sampler->temperature = config->temperature;
-    decode_sampler->repetition_penalty = config->repetition_penalty;
-    decode_sampler->do_sample = config->sample;
-    decode_sampler->top_k = config->top_k;
-    decode_sampler->top_p = config->top_p;
-    dctx->max_generation_size = config->max_tokens > model->max_delay ? config->max_tokens : model->max_generation_size;
+void dia_runner::configure_generation(generation_configuration *config) {
+  GGML_ASSERT(config->max_tokens == 0 || config->max_tokens > model->max_delay);
+  decode_sampler->temperature = config->temperature;
+  decode_sampler->repetition_penalty = config->repetition_penalty;
+  decode_sampler->do_sample = config->sample;
+  decode_sampler->top_k = config->top_k;
+  decode_sampler->top_p = config->top_p;
+  dctx->max_generation_size = config->max_tokens > model->max_delay
+                                  ? config->max_tokens
+                                  : model->max_generation_size;
 }
 
-void dia_runner::set_inputs(dia_ubatch & batch) {
-    if (batch.encoder_step) {
-        ggml_backend_tensor_set(dctx->inp_tokens, batch.tokens.data(), 0, batch.tokens.size()*ggml_element_size(dctx->inp_tokens));
-        int32_t * ep = (int32_t*) dctx->encode_positions->data;
-        float * mask = (float*) dctx->encode_attn_mask->data;
-        for (int i = 0; i < model->max_encoder_context_length; i++) {
-            ep[i] = (int32_t) i;
-            for (int ii = 0; ii < model->max_encoder_context_length; ii++) {
-                if (i < batch.sentence_length) {
-                    mask[i*model->max_encoder_context_length + ii] = ii < batch.sentence_length ? 0.0 : -INFINITY;
-                } else {
-                    mask[i*model->max_encoder_context_length + ii] = ii >= batch.sentence_length ? 0.0 : -INFINITY;
-                }
-            }
+void dia_runner::set_inputs(dia_ubatch &batch) {
+  if (batch.encoder_step) {
+    ggml_backend_tensor_set(dctx->inp_tokens, batch.tokens.data(), 0,
+                            batch.tokens.size() *
+                                ggml_element_size(dctx->inp_tokens));
+    int32_t *ep = (int32_t *)dctx->encode_positions->data;
+    float *mask = (float *)dctx->encode_attn_mask->data;
+    for (int i = 0; i < model->max_encoder_context_length; i++) {
+      ep[i] = (int32_t)i;
+      for (int ii = 0; ii < model->max_encoder_context_length; ii++) {
+        if (i < batch.sentence_length) {
+          mask[i * model->max_encoder_context_length + ii] =
+              ii < batch.sentence_length ? 0.0 : -INFINITY;
+        } else {
+          mask[i * model->max_encoder_context_length + ii] =
+              ii >= batch.sentence_length ? 0.0 : -INFINITY;
         }
+      }
     }
-    // The audio tokens need to be repeated in the input in order to support cfg-scaling. I.E we need duplicate inputs for conditional and unconditional logits.
-    ggml_backend_tensor_set(dctx->audio_inp_tokens, batch.audio_tokens.data(), 0, batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens));
-    ggml_backend_tensor_set(dctx->audio_inp_tokens, batch.audio_tokens.data(), batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens), batch.audio_tokens.size()*ggml_element_size(dctx->audio_inp_tokens));
-    ((int32_t*) dctx->positions->data)[0] = dctx->current_position;
+  }
+  // The audio tokens need to be repeated in the input in order to support
+  // cfg-scaling. I.E we need duplicate inputs for conditional and unconditional
+  // logits.
+  ggml_backend_tensor_set(dctx->audio_inp_tokens, batch.audio_tokens.data(), 0,
+                          batch.audio_tokens.size() *
+                              ggml_element_size(dctx->audio_inp_tokens));
+  ggml_backend_tensor_set(
+      dctx->audio_inp_tokens, batch.audio_tokens.data(),
+      batch.audio_tokens.size() * ggml_element_size(dctx->audio_inp_tokens),
+      batch.audio_tokens.size() * ggml_element_size(dctx->audio_inp_tokens));
+  ((int32_t *)dctx->positions->data)[0] = dctx->current_position;
 }
 
-int dia_runner::decode(dia_ubatch & batch) {
-    if (batch.encoder_step) {
-        dctx->prompt_size = batch.sentence_length;
-        dctx->output_tokens.reserve(dctx->max_generation_size * model->n_output_heads);
+int dia_runner::decode(dia_ubatch &batch) {
+  if (batch.encoder_step) {
+    dctx->prompt_size = batch.sentence_length;
+    dctx->output_tokens.reserve(dctx->max_generation_size *
+                                model->n_output_heads);
+  }
+  ggml_backend_sched_reset(dctx->sched);
+
+  const size_t logits_size = model->output_vocab_size *
+                             dctx->max_generation_size * model->n_output_heads;
+  const size_t prev_size =
+      dctx->buf_output ? ggml_backend_buffer_get_size(dctx->buf_output) : 0;
+  const size_t new_size = logits_size * sizeof(float);
+
+  if (!dctx->buf_output || prev_size < new_size) {
+    if (dctx->buf_output) {
+      ggml_backend_buffer_free(dctx->buf_output);
+      dctx->buf_output = nullptr;
+      dctx->logits = nullptr;
     }
-    ggml_backend_sched_reset(dctx->sched);
-        
-    const size_t logits_size = model->output_vocab_size * dctx->max_generation_size * model->n_output_heads;
-    const size_t prev_size = dctx->buf_output ? ggml_backend_buffer_get_size(dctx->buf_output) : 0;
-    const size_t new_size  = logits_size * sizeof(float);
-    
-    if (!dctx->buf_output || prev_size < new_size) {
-        if (dctx->buf_output) {
-            ggml_backend_buffer_free(dctx->buf_output);
-            dctx->buf_output = nullptr;
-            dctx->logits = nullptr;
-        }
 
-        dctx->buf_output = ggml_backend_buft_alloc_buffer(dctx->backend_cpu_buffer, new_size);
-    }
-    
-    dctx->logits = (float *) ggml_backend_buffer_get_base(dctx->buf_output);
+    dctx->buf_output =
+        ggml_backend_buft_alloc_buffer(dctx->backend_cpu_buffer, new_size);
+  }
 
-    ggml_cgraph * gf = build_dia_graph(batch);
+  dctx->logits = (float *)ggml_backend_buffer_get_base(dctx->buf_output);
 
-    // the output is always the last tensor in the graph
-    struct ggml_tensor * res = gf->nodes[gf->n_nodes - 1];
-    std::string resname = ggml_get_name(res);
-    ggml_backend_sched_alloc_graph(dctx->sched, gf);
+  ggml_cgraph *gf = build_dia_graph(batch);
 
-    set_inputs(batch);
+  // the output is always the last tensor in the graph
+  struct ggml_tensor *res = ggml_graph_node(gf, -1);
+  std::string resname = ggml_get_name(res);
+  ggml_backend_sched_alloc_graph(dctx->sched, gf);
 
-    ggml_backend_sched_graph_compute_async(dctx->sched, gf);
+  set_inputs(batch);
 
-    float * logits_out = dctx->logits + dctx->current_position * model->output_vocab_size * model->n_output_heads;
-    dctx->get_ggml_node_data(res, logits_out, model->output_vocab_size * model->n_output_heads * sizeof(float));
+  ggml_backend_sched_graph_compute_async(dctx->sched, gf);
 
-    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
-    // overlap with device computation.
-    ggml_backend_sched_reset(dctx->sched);
+  float *logits_out = dctx->logits + dctx->current_position *
+                                         model->output_vocab_size *
+                                         model->n_output_heads;
+  dctx->get_ggml_node_data(res, logits_out,
+                           model->output_vocab_size * model->n_output_heads *
+                               sizeof(float));
 
-    return 0;
+  // Reset state for the next token before backend sync, to allow the CPU
+  // activities in the reset to overlap with device computation.
+  ggml_backend_sched_reset(dctx->sched);
+
+  return 0;
 }
 
-dia_ubatch dia_runner::build_worst_case_batch()  {
-    struct dia_ubatch batch{ 1, true };
-    batch.tokens.resize(model->max_encoder_context_length * 2);
-    batch.audio_tokens.resize(model->n_output_heads);
-    return batch;
+dia_ubatch dia_runner::build_worst_case_batch() {
+  struct dia_ubatch batch {
+    1, true
+  };
+  batch.tokens.resize(model->max_encoder_context_length * 2);
+  batch.audio_tokens.resize(model->n_output_heads);
+  return batch;
 }
 
 void dia_runner::prepare_post_load() {
-    dac_runner->prepare_post_load();
-    dia_kv_cache_init(kv_cross_self, model, dctx);
-    auto batch = build_worst_case_batch();
-    batch.sentence_length = model->max_encoder_context_length;
-    dctx->prompt_size = model->max_encoder_context_length;
-    auto gf = build_dia_graph(batch);
-    dctx->prep_schedule(gf);
+  dac_runner->prepare_post_load();
+  dia_kv_cache_init(kv_cross_self, model, dctx);
+  auto batch = build_worst_case_batch();
+  batch.sentence_length = model->max_encoder_context_length;
+  dctx->prompt_size = model->max_encoder_context_length;
+  auto gf = build_dia_graph(batch);
+  dctx->prep_schedule(gf);
 }
 
-bool dia_runner::check_stopping(dia_ubatch & batch) {
-    if (dctx->delay_steps == -1 && (batch.audio_tokens[0] == model->eos_token_id || dctx->current_position >= dctx->max_generation_size - model->max_delay)) {
-        dctx->delay_steps = model->max_delay;
+bool dia_runner::check_stopping(dia_ubatch &batch) {
+  if (dctx->delay_steps == -1 &&
+      (batch.audio_tokens[0] == model->eos_token_id ||
+       dctx->current_position >=
+           dctx->max_generation_size - model->max_delay)) {
+    dctx->delay_steps = model->max_delay;
+  }
+
+  if (dctx->delay_steps > 0) {
+    int step_after_eos = model->max_delay - dctx->delay_steps;
+    for (int i = 0; i < model->delay_pattern.size(); i++) {
+      if (step_after_eos == model->delay_pattern[i]) {
+        batch.audio_tokens[i] = model->eos_token_id;
+      } else if (step_after_eos > model->delay_pattern[i]) {
+        batch.audio_tokens[i] = model->pad_token_id;
+      }
     }
-    
-    if (dctx->delay_steps > 0) {
-        int step_after_eos = model->max_delay - dctx->delay_steps;
-        for (int i = 0; i < model->delay_pattern.size(); i++) {
-            if (step_after_eos == model->delay_pattern[i]) {
-                batch.audio_tokens[i] = model->eos_token_id;
-            } else if (step_after_eos > model->delay_pattern[i]) {
-                batch.audio_tokens[i] = model->pad_token_id;
-            }
-        }
-        dctx->delay_steps -= 1;
-    }
-    return dctx->delay_steps == 0;
+    dctx->delay_steps -= 1;
+  }
+  return dctx->delay_steps == 0;
 }
 
-void dia_runner::adjust_output_tokens(std::vector<uint32_t> & output_tokens, std::vector<uint32_t> & filtered) {
-    // currently this is applying sliding window over the heads and filtering out bad tokens.
-    // If we convert the DAC model's quantizer layers to support by row + column embeddings then we will need to transpose
-    // the heads and the sequence here, but right now simplying using a strided view is more peformant.
-    size_t size = output_tokens.size();
-    filtered.reserve(size);
-    for (int i = 0; i < (size / model->n_output_heads) - model->max_delay; i++) {
-        bool skip_step = false;
-        for (int ii = 0; ii < model->n_output_heads; ii++) {
-            int next_index = i*model->n_output_heads+model->delay_pattern[ii]*model->n_output_heads+ii;
-            if (next_index > size || output_tokens[next_index] >= model->audio_vocab_size) {
-                skip_step = true;
-                break;
-            }
-        }
-        if (!skip_step) {
-            for (int ii = 0; ii < model->n_output_heads; ii++) {
-                int next_index = i*model->n_output_heads+model->delay_pattern[ii]*model->n_output_heads+ii;
-                filtered.push_back(output_tokens[next_index]);
-            }
-        }
+void dia_runner::adjust_output_tokens(std::vector<uint32_t> &output_tokens,
+                                      std::vector<uint32_t> &filtered) {
+  // currently this is applying sliding window over the heads and filtering out
+  // bad tokens. If we convert the DAC model's quantizer layers to support by
+  // row + column embeddings then we will need to transpose the heads and the
+  // sequence here, but right now simplying using a strided view is more
+  // peformant.
+  size_t size = output_tokens.size();
+  filtered.reserve(size);
+  for (int i = 0; i < (size / model->n_output_heads) - model->max_delay; i++) {
+    bool skip_step = false;
+    for (int ii = 0; ii < model->n_output_heads; ii++) {
+      int next_index = i * model->n_output_heads +
+                       model->delay_pattern[ii] * model->n_output_heads + ii;
+      if (next_index > size ||
+          output_tokens[next_index] >= model->audio_vocab_size) {
+        skip_step = true;
+        break;
+      }
     }
+    if (!skip_step) {
+      for (int ii = 0; ii < model->n_output_heads; ii++) {
+        int next_index = i * model->n_output_heads +
+                         model->delay_pattern[ii] * model->n_output_heads + ii;
+        filtered.push_back(output_tokens[next_index]);
+      }
+    }
+  }
 }
 
-int dia_runner::generate_from_batch(dia_ubatch & batch, struct tts_response * output) {
-    while (!check_stopping(batch)) {
-        int state = decode(batch);
-        if (state != 0) {
-            return state;
-        }
-        decode_sampler->sample(dctx->logits + dctx->current_position * model->n_output_heads * model->output_vocab_size, dctx->output_tokens);
-        dctx->current_position += batch.sequence_length;
-        batch = dia_ubatch{ 1 };
-        uint32_t * last_outputs = (dctx->output_tokens.data() + (int) dctx->output_tokens.size() - model->n_output_heads);
-        batch.audio_tokens.reserve(model->n_output_heads);
-        for (int i = 0; i < model->n_output_heads; i++) {
-            batch.audio_tokens.push_back(dctx->current_position > i ? last_outputs[i] : model->bos_token_id);
-        }
+int dia_runner::generate_from_batch(dia_ubatch &batch,
+                                    struct tts_response *output) {
+  while (!check_stopping(batch)) {
+    int state = decode(batch);
+    if (state != 0) {
+      return state;
     }
+    decode_sampler->sample(dctx->logits + dctx->current_position *
+                                              model->n_output_heads *
+                                              model->output_vocab_size,
+                           dctx->output_tokens);
+    dctx->current_position += batch.sequence_length;
+    batch = dia_ubatch{1};
+    uint32_t *last_outputs =
+        (dctx->output_tokens.data() + (int)dctx->output_tokens.size() -
+         model->n_output_heads);
+    batch.audio_tokens.reserve(model->n_output_heads);
+    for (int i = 0; i < model->n_output_heads; i++) {
+      batch.audio_tokens.push_back(
+          dctx->current_position > i ? last_outputs[i] : model->bos_token_id);
+    }
+  }
 
-    std::vector<uint32_t> filtered_output_tokens;
-    adjust_output_tokens(dctx->output_tokens, filtered_output_tokens);
+  std::vector<uint32_t> filtered_output_tokens;
+  adjust_output_tokens(dctx->output_tokens, filtered_output_tokens);
 
-    dac_runner->run(filtered_output_tokens.data(), (int32_t) filtered_output_tokens.size() / model->n_output_heads, output);
-    return 0;
+  dac_runner->run(
+      filtered_output_tokens.data(),
+      (int32_t)filtered_output_tokens.size() / model->n_output_heads, output);
+  return 0;
 }
 
-int dia_runner::generate(std::string sentence, struct tts_response * output) {
-    dia_ubatch batch = batch_from_sentence(sentence);
-    dctx->reset();
-    decode_sampler->reset();
-    dctx->current_position = 0;
-    if (!kv_cross_self) {
-        kv_cross_self = new dia_kv_cache;
-        if (!dia_kv_cache_init(kv_cross_self, model, dctx)) {
-            return 1;
-        }
+int dia_runner::generate(std::string sentence, struct tts_response *output) {
+  dia_ubatch batch = batch_from_sentence(sentence);
+  dctx->reset();
+  decode_sampler->reset();
+  dctx->current_position = 0;
+  if (!kv_cross_self) {
+    kv_cross_self = new dia_kv_cache;
+    if (!dia_kv_cache_init(kv_cross_self, model, dctx)) {
+      return 1;
     }
-    return generate_from_batch(batch, output);
+  }
+  return generate_from_batch(batch, output);
 }
 
-void dia_runner::assign_weight(std::string name, ggml_tensor * tensor) {
-    if (tensor->data == NULL) {
-        return;
-    }
+void dia_runner::assign_weight(std::string name, ggml_tensor *tensor) {
+  if (tensor->data == NULL) {
+    return;
+  }
 
-    if (name.size() == 0) {
-        // handles the top level meta tensor
-        return;
-    }
+  if (name.size() == 0) {
+    // handles the top level meta tensor
+    return;
+  }
 
-    if (name.size() > 14 && name.substr(0, 14) == "audio_encoder.") {
-        dac_runner->model->assign_weight(name.substr(14), tensor);
-    } else {
-        model->assign_weight(name, tensor);
-    }   
+  if (name.size() > 14 && name.substr(0, 14) == "audio_encoder.") {
+    dac_runner->model->assign_weight(name.substr(14), tensor);
+  } else {
+    model->assign_weight(name, tensor);
+  }
 }

--- a/src/ggml-tts-ext.cpp
+++ b/src/ggml-tts-ext.cpp
@@ -1,0 +1,334 @@
+#include "ggml-tts-ext.h"
+#include <cmath>
+#include <complex>
+#include <cstring>
+#include <vector>
+
+// Helper functions for FFT computation
+static void fft(std::vector<std::complex<float>> &x) {
+  const size_t N = x.size();
+  if (N <= 1)
+    return;
+
+  // Divide
+  std::vector<std::complex<float>> even(N / 2), odd(N / 2);
+  for (size_t i = 0; i < N / 2; i++) {
+    even[i] = x[i * 2];
+    odd[i] = x[i * 2 + 1];
+  }
+
+  // Conquer
+  fft(even);
+  fft(odd);
+
+  // Combine
+  for (size_t i = 0; i < N / 2; i++) {
+    std::complex<float> t =
+        std::polar(1.0f, -2.0f * (float)M_PI * (float)i / (float)N) * odd[i];
+    x[i] = even[i] + t;
+    x[i + N / 2] = even[i] - t;
+  }
+}
+
+static void ifft(std::vector<std::complex<float>> &x) {
+  // Conjugate the complex numbers
+  for (auto &val : x) {
+    val = std::conj(val);
+  }
+
+  // Forward FFT
+  fft(x);
+
+  // Conjugate the complex numbers again and scale
+  for (auto &val : x) {
+    val = std::conj(val) / static_cast<float>(x.size());
+  }
+}
+
+// Custom compute functions for map operations
+static void ggml_compute_mod_f32(struct ggml_tensor *dst,
+                                 const struct ggml_tensor *src, int ith,
+                                 int nth, void *userdata) {
+  const float mod_val = *(float *)userdata;
+  const int n = ggml_nrows(src);
+  const int nc = src->ne[0];
+
+  for (int i = ith; i < n; i += nth) {
+    const float *src_row = (float *)((char *)src->data + i * src->nb[1]);
+    float *dst_row = (float *)((char *)dst->data + i * dst->nb[1]);
+
+    for (int j = 0; j < nc; j++) {
+      dst_row[j] = fmodf(src_row[j], mod_val);
+    }
+  }
+}
+
+static void ggml_compute_cumsum(struct ggml_tensor *dst,
+                                const struct ggml_tensor *src, int ith, int nth,
+                                void *userdata) {
+  const int n = ggml_nrows(src);
+  const int nc = src->ne[0];
+
+  for (int i = ith; i < n; i += nth) {
+    const float *src_row = (float *)((char *)src->data + i * src->nb[1]);
+    float *dst_row = (float *)((char *)dst->data + i * dst->nb[1]);
+
+    float sum = 0.0f;
+    for (int j = 0; j < nc; j++) {
+      sum += src_row[j];
+      dst_row[j] = sum;
+    }
+  }
+}
+
+static void ggml_compute_upscale_linear(struct ggml_tensor *dst,
+                                        const struct ggml_tensor *src,
+                                        const struct ggml_tensor *param,
+                                        int ith, int nth, void *userdata) {
+  const int scale_factor = *(int *)param->data;
+  const int n = ggml_nrows(src);
+  const int nc = src->ne[0];
+
+  for (int i = ith; i < n; i += nth) {
+    const float *src_row = (float *)((char *)src->data + i * src->nb[1]);
+    float *dst_row = (float *)((char *)dst->data + i * dst->nb[1]);
+
+    for (int j = 0; j < nc; j++) {
+      for (int k = 0; k < scale_factor; k++) {
+        dst_row[j * scale_factor + k] = src_row[j];
+      }
+    }
+  }
+}
+
+static void ggml_compute_round(struct ggml_tensor *dst,
+                               const struct ggml_tensor *src, int ith, int nth,
+                               void *userdata) {
+  const int n = ggml_nrows(src);
+  const int nc = src->ne[0];
+
+  for (int i = ith; i < n; i += nth) {
+    const float *src_row = (float *)((char *)src->data + i * src->nb[1]);
+    float *dst_row = (float *)((char *)dst->data + i * dst->nb[1]);
+
+    for (int j = 0; j < nc; j++) {
+      dst_row[j] = roundf(src_row[j]);
+    }
+  }
+}
+
+// STFT computation parameters
+struct stft_params {
+  int filter_length;
+  int hop_length;
+  bool compute_abs_and_angle;
+};
+
+static void ggml_compute_stft(struct ggml_tensor *dst,
+                              const struct ggml_tensor *src,
+                              const struct ggml_tensor *window, int ith,
+                              int nth, void *userdata) {
+  const stft_params *params = (const stft_params *)userdata;
+  const int filter_length = params->filter_length;
+  const int hop_length = params->hop_length;
+  const bool compute_abs_and_angle = params->compute_abs_and_angle;
+
+  const int input_length = src->ne[0];
+  const int n_frames = (input_length - filter_length) / hop_length + 1;
+  const int freq_bins = filter_length;
+
+  const float *input = (const float *)src->data;
+  const float *win = (const float *)window->data;
+  float *output = (float *)dst->data;
+
+  // Process each frame
+  for (int frame = ith; frame < n_frames; frame += nth) {
+    const int start_idx = frame * hop_length;
+
+    // Prepare windowed frame for FFT
+    std::vector<std::complex<float>> frame_data(filter_length);
+    for (int i = 0; i < filter_length; i++) {
+      if (start_idx + i < input_length) {
+        frame_data[i] =
+            std::complex<float>(input[start_idx + i] * win[i], 0.0f);
+      } else {
+        frame_data[i] = std::complex<float>(0.0f, 0.0f);
+      }
+    }
+
+    // Compute FFT
+    fft(frame_data);
+
+    // Store results
+    for (int freq = 0; freq < freq_bins; freq++) {
+      if (compute_abs_and_angle) {
+        // Store magnitude and phase
+        float magnitude = std::abs(frame_data[freq]);
+        float phase = std::arg(frame_data[freq]);
+        output[freq * n_frames * 2 + frame * 2 + 0] = magnitude;
+        output[freq * n_frames * 2 + frame * 2 + 1] = phase;
+      } else {
+        // Store real and imaginary parts
+        output[freq * n_frames * 2 + frame * 2 + 0] = frame_data[freq].real();
+        output[freq * n_frames * 2 + frame * 2 + 1] = frame_data[freq].imag();
+      }
+    }
+  }
+}
+
+// ISTFT computation parameters
+struct istft_params {
+  int filter_length;
+  int hop_length;
+  bool from_abs_and_angle;
+};
+
+static void ggml_compute_istft(struct ggml_tensor *dst,
+                               const struct ggml_tensor *src,
+                               const struct ggml_tensor *window, int ith,
+                               int nth, void *userdata) {
+  const istft_params *params = (const istft_params *)userdata;
+  const int filter_length = params->filter_length;
+  const int hop_length = params->hop_length;
+  const bool from_abs_and_angle = params->from_abs_and_angle;
+
+  const int n_frames = src->ne[1];
+  const int freq_bins = src->ne[0];
+  const int output_length = (n_frames - 1) * hop_length + filter_length;
+
+  const float *input = (const float *)src->data;
+  const float *win = (const float *)window->data;
+  float *output = (float *)dst->data;
+
+  // Initialize output to zero
+  if (ith == 0) {
+    memset(output, 0, output_length * sizeof(float));
+  }
+
+  // Process each frame
+  for (int frame = ith; frame < n_frames; frame += nth) {
+    const int start_idx = frame * hop_length;
+
+    // Prepare frequency domain data for IFFT
+    std::vector<std::complex<float>> frame_data(filter_length);
+    for (int freq = 0; freq < freq_bins && freq < filter_length; freq++) {
+      if (from_abs_and_angle) {
+        // Convert from magnitude and phase
+        float magnitude = input[freq * n_frames * 2 + frame * 2 + 0];
+        float phase = input[freq * n_frames * 2 + frame * 2 + 1];
+        frame_data[freq] = std::polar(magnitude, phase);
+      } else {
+        // Use real and imaginary parts
+        float real = input[freq * n_frames * 2 + frame * 2 + 0];
+        float imag = input[freq * n_frames * 2 + frame * 2 + 1];
+        frame_data[freq] = std::complex<float>(real, imag);
+      }
+    }
+
+    // Fill remaining frequencies with conjugate symmetry for real output
+    for (int freq = freq_bins; freq < filter_length; freq++) {
+      int mirror_freq = filter_length - freq;
+      if (mirror_freq < freq_bins) {
+        frame_data[freq] = std::conj(frame_data[mirror_freq]);
+      } else {
+        frame_data[freq] = std::complex<float>(0.0f, 0.0f);
+      }
+    }
+
+    // Compute IFFT
+    ifft(frame_data);
+
+    // Apply window and overlap-add
+    for (int i = 0; i < filter_length; i++) {
+      if (start_idx + i < output_length) {
+        output[start_idx + i] += frame_data[i].real() * win[i];
+      }
+    }
+  }
+}
+
+// Modulo operation: a % b
+struct ggml_tensor *ggml_mod(struct ggml_context *ctx, struct ggml_tensor *a,
+                             float b) {
+  float *mod_val = (float *)malloc(sizeof(float));
+  *mod_val = b;
+
+  return ggml_map_custom1(ctx, a, ggml_compute_mod_f32, 1, mod_val);
+}
+
+// Cumulative sum along the first dimension
+struct ggml_tensor *ggml_cumsum(struct ggml_context *ctx,
+                                struct ggml_tensor *a) {
+  return ggml_map_custom1(ctx, a, ggml_compute_cumsum, 1, nullptr);
+}
+
+// Linear upscaling (repeat elements)
+struct ggml_tensor *ggml_upscale_linear(struct ggml_context *ctx,
+                                        struct ggml_tensor *a,
+                                        int scale_factor) {
+  // Store scale factor in a parameter tensor
+  struct ggml_tensor *scale_param = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, 1);
+  *(int *)scale_param->data = scale_factor;
+
+  return ggml_map_custom2(ctx, a, scale_param, ggml_compute_upscale_linear, 1,
+                          nullptr);
+}
+
+// Round to nearest integer
+struct ggml_tensor *ggml_round(struct ggml_context *ctx,
+                               struct ggml_tensor *a) {
+  return ggml_map_custom1(ctx, a, ggml_compute_round, 1, nullptr);
+}
+
+// Helper function to calculate number of frames
+static int64_t calculate_number_of_frames(int64_t length, size_t hop_length) {
+  return (int64_t)(length / (int64_t)hop_length) + 1;
+}
+
+// Helper function to calculate original length
+static int64_t calculate_original_length(int64_t frames, size_t hop_length) {
+  return (frames - 1) * (int64_t)hop_length;
+}
+
+// STFT implementation - adapted from ggml fork
+struct ggml_tensor *stft(struct ggml_context *ctx, struct ggml_tensor *a,
+                         struct ggml_tensor *window, size_t n_fft, size_t hop,
+                         bool abs_and_angle, bool one_sided) {
+  // Calculate output dimensions
+  int64_t n_frames = calculate_number_of_frames(a->ne[0], hop);
+  int64_t freq_bins = one_sided ? (n_fft / 2 + 1) : n_fft;
+
+  // Output tensor: [freq_bins, n_frames, 2] where last dim is real/imag or
+  // mag/phase
+  int64_t ne[4] = {freq_bins, n_frames, 2, 1};
+  struct ggml_tensor *result = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne);
+
+  // Create parameters
+  stft_params *params = (stft_params *)malloc(sizeof(stft_params));
+  params->filter_length = n_fft;
+  params->hop_length = hop;
+  params->compute_abs_and_angle = abs_and_angle;
+
+  return ggml_map_custom2(ctx, a, window, ggml_compute_stft, 1, params);
+}
+
+// ISTFT implementation - adapted from ggml fork
+struct ggml_tensor *istft(struct ggml_context *ctx, struct ggml_tensor *a,
+                          struct ggml_tensor *window_squared_sum,
+                          struct ggml_tensor *window, size_t n_fft, size_t hop,
+                          bool abs_and_angle, bool one_sided) {
+  // Calculate output dimensions
+  int64_t n_frames = a->ne[1];
+  int64_t output_length = calculate_original_length(n_frames, hop) + n_fft;
+
+  int64_t ne[4] = {output_length, 1, 1, 1};
+  struct ggml_tensor *result = ggml_new_tensor(ctx, GGML_TYPE_F32, 1, ne);
+
+  // Create parameters
+  istft_params *params = (istft_params *)malloc(sizeof(istft_params));
+  params->filter_length = n_fft;
+  params->hop_length = hop;
+  params->from_abs_and_angle = abs_and_angle;
+
+  return ggml_map_custom2(ctx, a, window, ggml_compute_istft, 1, params);
+}

--- a/src/ggml-tts-ext.h
+++ b/src/ggml-tts-ext.h
@@ -27,15 +27,17 @@ GGML_API struct ggml_tensor *ggml_upscale_linear(struct ggml_context *ctx,
 GGML_API struct ggml_tensor *ggml_round(struct ggml_context *ctx,
                                         struct ggml_tensor *a);
 
-// STFT wrapper functions (using standard GGML operations)
+// STFT with 7 parameters to match kokoro_model.cpp usage
 struct ggml_tensor *stft(struct ggml_context *ctx, struct ggml_tensor *a,
-                         struct ggml_tensor *window, size_t n_fft, size_t hop,
-                         bool abs_and_angle, bool one_sided);
+                         struct ggml_tensor *window, int filter_length,
+                         int hop_length, bool compute_abs_and_angle,
+                         bool center);
 
+// ISTFT with 8 parameters to match kokoro_model.cpp usage
 struct ggml_tensor *istft(struct ggml_context *ctx, struct ggml_tensor *a,
                           struct ggml_tensor *window_squared_sum,
-                          struct ggml_tensor *window, size_t n_fft, size_t hop,
-                          bool abs_and_angle, bool one_sided);
+                          struct ggml_tensor *window, int filter_length,
+                          int hop_length, bool from_abs_and_angle, bool center);
 
 #ifdef __cplusplus
 }

--- a/src/ggml-tts-ext.h
+++ b/src/ggml-tts-ext.h
@@ -1,0 +1,44 @@
+#ifndef GGML_TTS_EXT_H
+#define GGML_TTS_EXT_H
+
+#include "ggml.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// TTS-specific GGML extensions
+// These are the minimal functions needed from mmwillet's fork
+
+// Modulo operation: a % b
+GGML_API struct ggml_tensor *ggml_mod(struct ggml_context *ctx,
+                                      struct ggml_tensor *a, float b);
+
+// Cumulative sum along the first dimension
+GGML_API struct ggml_tensor *ggml_cumsum(struct ggml_context *ctx,
+                                         struct ggml_tensor *a);
+
+// Linear upscaling (repeat elements)
+GGML_API struct ggml_tensor *ggml_upscale_linear(struct ggml_context *ctx,
+                                                 struct ggml_tensor *a,
+                                                 int scale_factor);
+
+// Round to nearest integer
+GGML_API struct ggml_tensor *ggml_round(struct ggml_context *ctx,
+                                        struct ggml_tensor *a);
+
+// STFT wrapper functions (using standard GGML operations)
+struct ggml_tensor *stft(struct ggml_context *ctx, struct ggml_tensor *a,
+                         struct ggml_tensor *window, size_t n_fft, size_t hop,
+                         bool abs_and_angle, bool one_sided);
+
+struct ggml_tensor *istft(struct ggml_context *ctx, struct ggml_tensor *a,
+                          struct ggml_tensor *window_squared_sum,
+                          struct ggml_tensor *window, size_t n_fft, size_t hop,
+                          bool abs_and_angle, bool one_sided);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GGML_TTS_EXT_H

--- a/src/kokoro_model.cpp
+++ b/src/kokoro_model.cpp
@@ -1,1441 +1,1849 @@
 #include "kokoro_model.h"
 
-static struct ggml_tensor * build_albert_attn_mask(ggml_context * ctx, struct kokoro_duration_context *kctx, const kokoro_ubatch & batch) {
-    kctx->attn_mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, (int64_t) batch.n_tokens, (int64_t) batch.n_tokens);
-    ggml_set_input(kctx->attn_mask);
+static struct ggml_tensor *
+build_albert_attn_mask(ggml_context *ctx, struct kokoro_duration_context *kctx,
+                       const kokoro_ubatch &batch) {
+  kctx->attn_mask = ggml_new_tensor_2d(
+      ctx, GGML_TYPE_F32, (int64_t)batch.n_tokens, (int64_t)batch.n_tokens);
+  ggml_set_input(kctx->attn_mask);
 
-    return kctx->attn_mask;
+  return kctx->attn_mask;
 }
 
-static struct ggml_tensor * build_albert_inputs(ggml_context * ctx, kokoro_model * model, ggml_tensor * input_tokens, ggml_tensor * positions, ggml_tensor * token_types) {
-	struct ggml_tensor * tinpts = ggml_cont(ctx, ggml_get_rows(ctx, model->token_embd, input_tokens));
-	struct ggml_tensor * pinpts = ggml_get_rows(ctx, model->position_embd, positions);
+static struct ggml_tensor *build_albert_inputs(ggml_context *ctx,
+                                               kokoro_model *model,
+                                               ggml_tensor *input_tokens,
+                                               ggml_tensor *positions,
+                                               ggml_tensor *token_types) {
+  struct ggml_tensor *tinpts =
+      ggml_cont(ctx, ggml_get_rows(ctx, model->token_embd, input_tokens));
+  struct ggml_tensor *pinpts =
+      ggml_get_rows(ctx, model->position_embd, positions);
 
-	struct ggml_tensor * inpts = ggml_cont(ctx, ggml_add(ctx, tinpts, pinpts));
-	if (!model->static_token_types) {
-		// Token type embeddings are actually static for kokoro at the moment, so we should never need to compute this on the fly.
-		return ggml_add(ctx, inpts, ggml_get_rows(ctx, model->token_type_embd, token_types));
-	}
-	struct ggml_tensor * ainpts = ggml_add(ctx, inpts, model->static_token_type_values);
+  struct ggml_tensor *inpts = ggml_cont(ctx, ggml_add(ctx, tinpts, pinpts));
+  if (!model->static_token_types) {
+    // Token type embeddings are actually static for kokoro at the moment, so we
+    // should never need to compute this on the fly.
+    return ggml_add(ctx, inpts,
+                    ggml_get_rows(ctx, model->token_type_embd, token_types));
+  }
+  struct ggml_tensor *ainpts =
+      ggml_add(ctx, inpts, model->static_token_type_values);
 
-	struct ggml_tensor * out = ggml_cont(ctx, build_albert_norm(ctx, ainpts, model->input_norm_weight, model->input_norm_bias));
-	return ggml_add(ctx, ggml_mul_mat(ctx, model->embd_hidden, out), model->embd_hidden_bias);
+  struct ggml_tensor *out =
+      ggml_cont(ctx, build_albert_norm(ctx, ainpts, model->input_norm_weight,
+                                       model->input_norm_bias));
+  return ggml_add(ctx, ggml_mul_mat(ctx, model->embd_hidden, out),
+                  model->embd_hidden_bias);
 }
 
-static struct ggml_tensor * build_albert_norm(ggml_context * ctx, ggml_tensor * cur, ggml_tensor * weight, ggml_tensor * bias) {
-	// this is the standard eps for Albert
-	float eps = 0.000000000001;
-    cur = ggml_norm(ctx, cur, eps);
-    cur = ggml_cont(ctx, ggml_add(ctx, ggml_mul(ctx, cur, weight), bias));
-    return cur;
+static struct ggml_tensor *build_albert_norm(ggml_context *ctx,
+                                             ggml_tensor *cur,
+                                             ggml_tensor *weight,
+                                             ggml_tensor *bias) {
+  // this is the standard eps for Albert
+  float eps = 0.000000000001;
+  cur = ggml_norm(ctx, cur, eps);
+  cur = ggml_cont(ctx, ggml_add(ctx, ggml_mul(ctx, cur, weight), bias));
+  return cur;
 }
 
-static struct ggml_tensor * build_lstm(ggml_context * ctx, ggml_tensor * input, lstm* rnn, uint32_t sequence_length) {
-	struct ggml_tensor * resp = input;
-	struct ggml_tensor * reverse_resp = input;
+static struct ggml_tensor *build_lstm(ggml_context *ctx, ggml_tensor *input,
+                                      lstm *rnn, uint32_t sequence_length) {
+  struct ggml_tensor *resp = input;
+  struct ggml_tensor *reverse_resp = input;
 
-	// iterate over cells first so that at each pass to the next cell we have a fully formed vector (this improves performance as well as allocation for stacked lstms)
-	for (int c = 0; c < rnn->cells.size(); c++) {
-		resp = build_lstm_run(ctx, resp, rnn->hidden[c], rnn->states[c], rnn->cells[c]->weights, rnn->cells[c]->biases, sequence_length);
-		if (rnn->bidirectional) {
-			reverse_resp = build_lstm_run(ctx, reverse_resp, rnn->hidden[c], rnn->states[c], rnn->cells[c]->reverse_weights, rnn->cells[c]->reverse_biases, sequence_length, true);
-		}
-	}
-	if (rnn->bidirectional) {
-		resp = ggml_concat(ctx, resp, reverse_resp, 0);
-	}
-	return resp;
+  // iterate over cells first so that at each pass to the next cell we have a
+  // fully formed vector (this improves performance as well as allocation for
+  // stacked lstms)
+  for (int c = 0; c < rnn->cells.size(); c++) {
+    resp = build_lstm_run(ctx, resp, rnn->hidden[c], rnn->states[c],
+                          rnn->cells[c]->weights, rnn->cells[c]->biases,
+                          sequence_length);
+    if (rnn->bidirectional) {
+      reverse_resp =
+          build_lstm_run(ctx, reverse_resp, rnn->hidden[c], rnn->states[c],
+                         rnn->cells[c]->reverse_weights,
+                         rnn->cells[c]->reverse_biases, sequence_length, true);
+    }
+  }
+  if (rnn->bidirectional) {
+    resp = ggml_concat(ctx, resp, reverse_resp, 0);
+  }
+  return resp;
 }
 
-static struct ggml_tensor * build_lstm_run(ggml_context * ctx, ggml_tensor * input, ggml_tensor * h_0, ggml_tensor * c_0, std::vector<ggml_tensor*> weights, std::vector<ggml_tensor*> biases, uint32_t sequence_length, bool reversed) {
-	struct ggml_tensor * I = ggml_add(ctx, ggml_mul_mat(ctx, weights[0], input), biases[0]);
-	struct ggml_tensor * F = ggml_add(ctx, ggml_mul_mat(ctx, weights[2], input), biases[2]);
-	struct ggml_tensor * G = ggml_add(ctx, ggml_mul_mat(ctx, weights[4], input), biases[4]);
-	struct ggml_tensor * O = ggml_add(ctx, ggml_mul_mat(ctx, weights[6], input), biases[6]);
+static struct ggml_tensor *build_lstm_run(ggml_context *ctx, ggml_tensor *input,
+                                          ggml_tensor *h_0, ggml_tensor *c_0,
+                                          std::vector<ggml_tensor *> weights,
+                                          std::vector<ggml_tensor *> biases,
+                                          uint32_t sequence_length,
+                                          bool reversed) {
+  struct ggml_tensor *I =
+      ggml_add(ctx, ggml_mul_mat(ctx, weights[0], input), biases[0]);
+  struct ggml_tensor *F =
+      ggml_add(ctx, ggml_mul_mat(ctx, weights[2], input), biases[2]);
+  struct ggml_tensor *G =
+      ggml_add(ctx, ggml_mul_mat(ctx, weights[4], input), biases[4]);
+  struct ggml_tensor *O =
+      ggml_add(ctx, ggml_mul_mat(ctx, weights[6], input), biases[6]);
 
-	struct ggml_tensor * outputs;
+  struct ggml_tensor *outputs;
 
-	for (int index = 0; index < sequence_length; index++) {
-		int i = reversed ? sequence_length - 1 - index : index;
-		struct ggml_tensor * I_cur = ggml_view_3d(ctx, I, I->ne[0], 1, I->ne[2], I->nb[0], I->nb[1], I->nb[1]*i);
-		I_cur = ggml_sigmoid(ctx, ggml_add(ctx, I_cur, ggml_add(ctx, ggml_mul_mat(ctx, weights[1], h_0), biases[1])));
-		
-		struct ggml_tensor * F_cur = ggml_view_3d(ctx, F, F->ne[0], 1, F->ne[2], F->nb[0], F->nb[1], F->nb[1]*i);
-		F_cur = ggml_sigmoid(ctx, ggml_add(ctx, F_cur, ggml_add(ctx, ggml_mul_mat(ctx, weights[3], h_0), biases[3])));
-		
-		struct ggml_tensor * G_cur = ggml_view_3d(ctx, G, G->ne[0], 1, G->ne[2], G->nb[0], G->nb[1], G->nb[1]*i);
-		G_cur = ggml_tanh(ctx, ggml_add(ctx, G_cur, ggml_add(ctx, ggml_mul_mat(ctx, weights[5], h_0), biases[5])));
-		
-		struct ggml_tensor * O_cur = ggml_view_3d(ctx, O, O->ne[0], 1, O->ne[2], O->nb[0], O->nb[1], O->nb[1]*i);
-		O_cur = ggml_sigmoid(ctx, ggml_add(ctx, O_cur, ggml_add(ctx, ggml_mul_mat(ctx, weights[7], h_0), biases[7])));
-		
-		c_0 = ggml_add(ctx, ggml_mul(ctx, F_cur, c_0), ggml_mul(ctx, I_cur, G_cur));
-		h_0 = ggml_mul(ctx, ggml_tanh(ctx, c_0), O_cur);
+  for (int index = 0; index < sequence_length; index++) {
+    int i = reversed ? sequence_length - 1 - index : index;
+    struct ggml_tensor *I_cur = ggml_view_3d(ctx, I, I->ne[0], 1, I->ne[2],
+                                             I->nb[0], I->nb[1], I->nb[1] * i);
+    I_cur = ggml_sigmoid(
+        ctx,
+        ggml_add(ctx, I_cur,
+                 ggml_add(ctx, ggml_mul_mat(ctx, weights[1], h_0), biases[1])));
 
-		if (index == 0) {
-			outputs = h_0;
-		} else {
-			outputs = reversed ? ggml_concat(ctx, h_0, outputs, 1) : ggml_concat(ctx, outputs, h_0, 1);
-		}
-	}
-	return outputs;
+    struct ggml_tensor *F_cur = ggml_view_3d(ctx, F, F->ne[0], 1, F->ne[2],
+                                             F->nb[0], F->nb[1], F->nb[1] * i);
+    F_cur = ggml_sigmoid(
+        ctx,
+        ggml_add(ctx, F_cur,
+                 ggml_add(ctx, ggml_mul_mat(ctx, weights[3], h_0), biases[3])));
+
+    struct ggml_tensor *G_cur = ggml_view_3d(ctx, G, G->ne[0], 1, G->ne[2],
+                                             G->nb[0], G->nb[1], G->nb[1] * i);
+    G_cur = ggml_tanh(
+        ctx,
+        ggml_add(ctx, G_cur,
+                 ggml_add(ctx, ggml_mul_mat(ctx, weights[5], h_0), biases[5])));
+
+    struct ggml_tensor *O_cur = ggml_view_3d(ctx, O, O->ne[0], 1, O->ne[2],
+                                             O->nb[0], O->nb[1], O->nb[1] * i);
+    O_cur = ggml_sigmoid(
+        ctx,
+        ggml_add(ctx, O_cur,
+                 ggml_add(ctx, ggml_mul_mat(ctx, weights[7], h_0), biases[7])));
+
+    c_0 = ggml_add(ctx, ggml_mul(ctx, F_cur, c_0), ggml_mul(ctx, I_cur, G_cur));
+    h_0 = ggml_mul(ctx, ggml_tanh(ctx, c_0), O_cur);
+
+    if (index == 0) {
+      outputs = h_0;
+    } else {
+      outputs = reversed ? ggml_concat(ctx, h_0, outputs, 1)
+                         : ggml_concat(ctx, outputs, h_0, 1);
+    }
+  }
+  return outputs;
 }
 
-static struct ggml_tensor * build_ada_residual_conv(ggml_context * ctx, struct ggml_tensor * x, ada_residual_conv_block * block, struct ggml_tensor * style, struct ggml_tensor * sqrt_tensor) {
-	struct ggml_tensor * cur = x;
-	struct ggml_tensor * gamma;
-	struct ggml_tensor * beta;
+static struct ggml_tensor *build_ada_residual_conv(
+    ggml_context *ctx, struct ggml_tensor *x, ada_residual_conv_block *block,
+    struct ggml_tensor *style, struct ggml_tensor *sqrt_tensor) {
+  struct ggml_tensor *cur = x;
+  struct ggml_tensor *gamma;
+  struct ggml_tensor *beta;
 
-	gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->norm1_gamma, style), block->norm1_gamma_bias);
-	beta  = ggml_add(ctx, ggml_mul_mat(ctx, block->norm1_beta, style), block->norm1_beta_bias);
-	cur   = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)), 0.00001)));
+  gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->norm1_gamma, style),
+                   block->norm1_gamma_bias);
+  beta = ggml_add(ctx, ggml_mul_mat(ctx, block->norm1_beta, style),
+                  block->norm1_beta_bias);
+  cur = ggml_cont(
+      ctx, ggml_transpose(
+               ctx, ggml_norm(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)),
+                              0.00001)));
 
-	// The addition between gamma * x and x is performed here because ggml doesn't support scalar multiplication without initializing the scalars in advance.
-	// An optimal remedy to this would be to increment the gamma bias above by one when preparing the gguf file for the model.
-	cur   = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
-	cur   = ggml_leaky_relu(ctx, cur, 0.2f, false);
+  // The addition between gamma * x and x is performed here because ggml doesn't
+  // support scalar multiplication without initializing the scalars in advance.
+  // An optimal remedy to this would be to increment the gamma bias above by one
+  // when preparing the gguf file for the model.
+  cur = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
+  cur = ggml_leaky_relu(ctx, cur, 0.2f, false);
 
-	if (block->pool) {
-		cur = ggml_conv_transpose_1d(ctx, block->pool, ggml_cont(ctx, ggml_transpose(ctx, cur)), 2, 1, 1, 1, cur->ne[0]);
-		cur = ggml_add(ctx, cur, block->pool_bias);
-		cur = ggml_cont(ctx, ggml_transpose(ctx, cur));
-	}
+  if (block->pool) {
+    cur = ggml_conv_transpose_1d(
+        ctx, block->pool, ggml_cont(ctx, ggml_transpose(ctx, cur)), 2, 1, 1);
+    cur = ggml_add(ctx, cur, block->pool_bias);
+    cur = ggml_cont(ctx, ggml_transpose(ctx, cur));
+  }
 
- 	cur = ggml_conv_1d(ctx, block->conv1, ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, 1, 1);
+  cur = ggml_conv_1d(ctx, block->conv1,
+                     ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, 1, 1);
 
-	cur   = ggml_add(ctx, cur, block->conv1_bias);
-	gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->norm2_gamma, style), block->norm2_gamma_bias);
-	beta  = ggml_add(ctx, ggml_mul_mat(ctx, block->norm2_beta, style), block->norm2_beta_bias);
-	cur   = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, cur, 0.00001)));
+  cur = ggml_add(ctx, cur, block->conv1_bias);
+  gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->norm2_gamma, style),
+                   block->norm2_gamma_bias);
+  beta = ggml_add(ctx, ggml_mul_mat(ctx, block->norm2_beta, style),
+                  block->norm2_beta_bias);
+  cur = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, cur, 0.00001)));
 
-	// The addition between gamma * x and x is performed here because ggml doesn't support scalar multiplication without initializing the scalars in advance.
-	// An optimal remedy to this would be to increment the gamma bias above by one when preparing the gguf file for the model.
-	cur   = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
-	cur   = ggml_leaky_relu(ctx, cur, 0.2f, false);
-	cur   = ggml_add(ctx, ggml_conv_1d(ctx, block->conv2, ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, 1, 1), block->conv2_bias);
+  // The addition between gamma * x and x is performed here because ggml doesn't
+  // support scalar multiplication without initializing the scalars in advance.
+  // An optimal remedy to this would be to increment the gamma bias above by one
+  // when preparing the gguf file for the model.
+  cur = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
+  cur = ggml_leaky_relu(ctx, cur, 0.2f, false);
+  cur =
+      ggml_add(ctx,
+               ggml_conv_1d(ctx, block->conv2,
+                            ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, 1, 1),
+               block->conv2_bias);
 
-	struct ggml_tensor * res = cur;	
-	cur = ggml_cont(ctx, ggml_transpose(ctx, x));
-	if (block->upsample) {
-		if (block->pool) {
-			cur = ggml_upscale_ext(ctx, cur, cur->ne[0]*2, cur->ne[1], cur->ne[2], cur->ne[3]);
-		}
-		cur = ggml_conv_1d(ctx, block->upsample, cur, 1, 0, 1);
-	}
+  struct ggml_tensor *res = cur;
+  cur = ggml_cont(ctx, ggml_transpose(ctx, x));
+  if (block->upsample) {
+    if (block->pool) {
+      cur = ggml_upscale_ext(ctx, cur, cur->ne[0] * 2, cur->ne[1], cur->ne[2],
+                             cur->ne[3], GGML_SCALE_MODE_NEAREST);
+    }
+    cur = ggml_conv_1d(ctx, block->upsample, cur, 1, 0, 1);
+  }
 
-	return ggml_cont(ctx, ggml_transpose(ctx, ggml_div(ctx, ggml_add(ctx, res, cur), sqrt_tensor)));
+  return ggml_cont(
+      ctx,
+      ggml_transpose(ctx, ggml_div(ctx, ggml_add(ctx, res, cur), sqrt_tensor)));
 }
 
-static struct ggml_tensor * build_kokoro_generator_res_block(ggml_context * ctx, struct ggml_tensor * x, struct ggml_tensor * style, kokoro_generator_residual_block * block) {
-	struct ggml_tensor * cur;
-	struct ggml_tensor * gamma;
-	struct ggml_tensor * beta;
-	struct ggml_tensor * inpl = x;
-	for (int i = 0; i < block->convs1_weights.size(); i++) {
-		gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->adain1d_1_gamma_weights[i], style), block->adain1d_1_gamma_biases[i]);
-		beta  = ggml_add(ctx, ggml_mul_mat(ctx, block->adain1d_1_beta_weights[i], style), block->adain1d_1_beta_biases[i]);
-		cur   = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, inpl, 0.00001)));
+static struct ggml_tensor *
+build_kokoro_generator_res_block(ggml_context *ctx, struct ggml_tensor *x,
+                                 struct ggml_tensor *style,
+                                 kokoro_generator_residual_block *block) {
+  struct ggml_tensor *cur;
+  struct ggml_tensor *gamma;
+  struct ggml_tensor *beta;
+  struct ggml_tensor *inpl = x;
+  for (int i = 0; i < block->convs1_weights.size(); i++) {
+    gamma = ggml_add(
+        ctx, ggml_mul_mat(ctx, block->adain1d_1_gamma_weights[i], style),
+        block->adain1d_1_gamma_biases[i]);
+    beta = ggml_add(ctx,
+                    ggml_mul_mat(ctx, block->adain1d_1_beta_weights[i], style),
+                    block->adain1d_1_beta_biases[i]);
+    cur = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, inpl, 0.00001)));
 
-		// The addition between gamma * x and x is performed here because ggml doesn't support scalar multiplication without initializing the scalars in advance.
-		// An optimal remedy to this would be to increment the gamma bias above by one when preparing the gguf file for the model.
-		cur   = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
-		cur   = snake_1d(ctx, block->input_alphas[i], ggml_cont(ctx, ggml_transpose(ctx, cur)));
+    // The addition between gamma * x and x is performed here because ggml
+    // doesn't support scalar multiplication without initializing the scalars in
+    // advance. An optimal remedy to this would be to increment the gamma bias
+    // above by one when preparing the gguf file for the model.
+    cur = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
+    cur = snake_1d(ctx, block->input_alphas[i],
+                   ggml_cont(ctx, ggml_transpose(ctx, cur)));
 
-		cur   = ggml_add(ctx, ggml_conv_1d(ctx, block->convs1_weights[i], cur, 1, block->conv1_paddings[i], block->conv1_dilations[i]), block->convs1_biases[i]);
-		gamma = ggml_add(ctx, ggml_mul_mat(ctx, block->adain1d_2_gamma_weights[i], style), block->adain1d_2_gamma_biases[i]);
-		beta  = ggml_add(ctx, ggml_mul_mat(ctx, block->adain1d_2_beta_weights[i], style), block->adain1d_2_beta_biases[i]);
-		cur   = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, cur, 0.00001)));
+    cur = ggml_add(ctx,
+                   ggml_conv_1d(ctx, block->convs1_weights[i], cur, 1,
+                                block->conv1_paddings[i],
+                                block->conv1_dilations[i]),
+                   block->convs1_biases[i]);
+    gamma = ggml_add(
+        ctx, ggml_mul_mat(ctx, block->adain1d_2_gamma_weights[i], style),
+        block->adain1d_2_gamma_biases[i]);
+    beta = ggml_add(ctx,
+                    ggml_mul_mat(ctx, block->adain1d_2_beta_weights[i], style),
+                    block->adain1d_2_beta_biases[i]);
+    cur = ggml_cont(ctx, ggml_transpose(ctx, ggml_norm(ctx, cur, 0.00001)));
 
-		// The addition between gamma * x and x is performed here because ggml doesn't support scalar multiplication without initializing the scalars in advance.
-		// An optimal remedy to this would be to increment the gamma bias above by one when preparing the gguf file for the model.
-		cur   = ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta)));
+    // The addition between gamma * x and x is performed here because ggml
+    // doesn't support scalar multiplication without initializing the scalars in
+    // advance. An optimal remedy to this would be to increment the gamma bias
+    // above by one when preparing the gguf file for the model.
+    cur = ggml_cont(
+        ctx,
+        ggml_transpose(
+            ctx, ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)),
+                          beta)));
 
-		cur   = snake_1d(ctx, block->output_alphas[i], cur);
-		cur   = ggml_add(ctx, ggml_conv_1d(ctx, block->convs2_weights[i], cur, 1, block->conv1_paddings[0], 1), block->convs2_biases[i]);
-		inpl   = ggml_add(ctx, inpl, cur);
-	}
-	return inpl;
+    cur = snake_1d(ctx, block->output_alphas[i], cur);
+    cur = ggml_add(ctx,
+                   ggml_conv_1d(ctx, block->convs2_weights[i], cur, 1,
+                                block->conv1_paddings[0], 1),
+                   block->convs2_biases[i]);
+    inpl = ggml_add(ctx, inpl, cur);
+  }
+  return inpl;
 }
 
-static struct ggml_tensor * build_noise_block(ggml_context * ctx, kokoro_noise_residual_block * block, struct ggml_tensor * x, struct ggml_tensor * style) {
-	ggml_tensor * cur = ggml_add(ctx, ggml_conv_1d(ctx, block->input_conv, x, block->input_conv_stride, block->input_conv_padding, 1), block->input_conv_bias);
-	return build_kokoro_generator_res_block(ctx, cur, style, block->res_block);
+static struct ggml_tensor *build_noise_block(ggml_context *ctx,
+                                             kokoro_noise_residual_block *block,
+                                             struct ggml_tensor *x,
+                                             struct ggml_tensor *style) {
+  ggml_tensor *cur =
+      ggml_add(ctx,
+               ggml_conv_1d(ctx, block->input_conv, x, block->input_conv_stride,
+                            block->input_conv_padding, 1),
+               block->input_conv_bias);
+  return build_kokoro_generator_res_block(ctx, cur, style, block->res_block);
 }
 
-static struct ggml_tensor * build_sin_gen(ggml_context * ctx, kokoro_model * model, kokoro_context * kctx, struct ggml_tensor * x, int harmonic_num, int sequence_length, float voice_threshold, float sin_amp, float noise_std) {
-	struct ggml_tensor * cur = ggml_mul(ctx, ggml_repeat(ctx, x, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, x->ne[0], harmonic_num)), model->harmonic_sampling_norm);
-	cur = ggml_mul(ctx, ggml_cumsum(ctx, ggml_mod(ctx, cur, 1.0f)), model->sampling_factor_scalar);
-	cur = ggml_upscale_linear(ctx, cur, 300);
-	struct ggml_tensor * upscaled = ggml_upscale_ext(ctx, x, x->ne[0]*300, x->ne[1], x->ne[2], x->ne[3]);
+static struct ggml_tensor *
+build_sin_gen(ggml_context *ctx, kokoro_model *model, kokoro_context *kctx,
+              struct ggml_tensor *x, int harmonic_num, int sequence_length,
+              float voice_threshold, float sin_amp, float noise_std) {
+  struct ggml_tensor *cur =
+      ggml_mul(ctx,
+               ggml_repeat(ctx, x,
+                           ggml_new_tensor_2d(ctx, GGML_TYPE_F32, x->ne[0],
+                                              harmonic_num)),
+               model->harmonic_sampling_norm);
+  cur = ggml_mul(ctx, ggml_cumsum(ctx, ggml_mod(ctx, cur, 1.0f)),
+                 model->sampling_factor_scalar);
+  cur = ggml_upscale_linear(ctx, cur, 300);
+  struct ggml_tensor *upscaled =
+      ggml_upscale_ext(ctx, x, x->ne[0] * 300, x->ne[1], x->ne[2], x->ne[3],
+                       GGML_SCALE_MODE_NEAREST);
 
-	kctx->uv_noise_data = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, sequence_length*harmonic_num+4);
-	ggml_set_input(kctx->uv_noise_data);
+  kctx->uv_noise_data = ggml_new_tensor_1d(ctx, GGML_TYPE_I32,
+                                           sequence_length * harmonic_num + 4);
+  ggml_set_input(kctx->uv_noise_data);
 
-    struct ggml_tensor * fake = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, sequence_length, harmonic_num, 2);
+  struct ggml_tensor *fake =
+      ggml_new_tensor_3d(ctx, GGML_TYPE_F32, sequence_length, harmonic_num, 2);
 
-    // ggml doesn't support boolean tensors nor does it support greater than and roll ops. As a result, we represent these boolean tensors as 1.0 or 0.0 or simply perform
-    // multiplications in place via a custom map.
-    struct ggml_tensor * uv_noise = ggml_map_custom3(ctx, fake, upscaled, kctx->uv_noise_data, &uv_noise_compute, sequence_length, nullptr);
+  // ggml doesn't support boolean tensors nor does it support greater than and
+  // roll ops. As a result, we represent these boolean tensors as 1.0 or 0.0 or
+  // simply perform multiplications in place via a custom map.
+  struct ggml_tensor *uv_noise =
+      ggml_map_custom3(ctx, fake, upscaled, kctx->uv_noise_data,
+                       &uv_noise_compute, sequence_length, nullptr);
 
+  struct ggml_tensor *noise = ggml_cont(
+      ctx, ggml_view_2d(ctx, uv_noise, uv_noise->ne[0], uv_noise->ne[1],
+                        uv_noise->nb[1], uv_noise->nb[2]));
+  struct ggml_tensor *uv =
+      ggml_cont(ctx, ggml_view_2d(ctx, uv_noise, uv_noise->ne[0],
+                                  uv_noise->ne[1], uv_noise->nb[1], 0));
 
-    struct ggml_tensor * noise = ggml_cont(ctx, ggml_view_2d(ctx, uv_noise, uv_noise->ne[0], uv_noise->ne[1], uv_noise->nb[1], uv_noise->nb[2]));
-    struct ggml_tensor * uv = ggml_cont(ctx, ggml_view_2d(ctx, uv_noise, uv_noise->ne[0], uv_noise->ne[1], uv_noise->nb[1], 0));
-
-	return ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_mul(ctx, ggml_sin(ctx, cur), uv), noise)));
+  return ggml_cont(
+      ctx,
+      ggml_transpose(
+          ctx, ggml_add(ctx, ggml_mul(ctx, ggml_sin(ctx, cur), uv), noise)));
 }
 
-static struct ggml_tensor * build_generator(ggml_context * ctx, kokoro_model * model, kokoro_context * kctx, struct ggml_tensor * x, struct ggml_tensor * style, struct ggml_tensor * f0_curve, kokoro_generator* generator, int sequence_length, struct ggml_tensor * window_sq_sum, ggml_cgraph * gf) {
-	struct ggml_tensor * sing = build_sin_gen(ctx, model, kctx, f0_curve, model->harmonic_num + 1, f0_curve->ne[0] * 300, model->voice_threshold, model->sin_amp, model->noise_std);
-	struct ggml_tensor * har = ggml_tanh(ctx, ggml_add(ctx, ggml_mul_mat(ctx, generator->m_source_weight, sing), generator->m_source_bias));
+static struct ggml_tensor *
+build_generator(ggml_context *ctx, kokoro_model *model, kokoro_context *kctx,
+                struct ggml_tensor *x, struct ggml_tensor *style,
+                struct ggml_tensor *f0_curve, kokoro_generator *generator,
+                int sequence_length, struct ggml_tensor *window_sq_sum,
+                ggml_cgraph *gf) {
+  struct ggml_tensor *sing =
+      build_sin_gen(ctx, model, kctx, f0_curve, model->harmonic_num + 1,
+                    f0_curve->ne[0] * 300, model->voice_threshold,
+                    model->sin_amp, model->noise_std);
+  struct ggml_tensor *har = ggml_tanh(
+      ctx, ggml_add(ctx, ggml_mul_mat(ctx, generator->m_source_weight, sing),
+                    generator->m_source_bias));
 
-	har = stft(ctx, ggml_cont(ctx, ggml_transpose(ctx, har)), generator->window, model->true_n_fft, model->stft_hop, true, true);
+  har = stft(ctx, ggml_cont(ctx, ggml_transpose(ctx, har)), generator->window,
+             model->true_n_fft, model->stft_hop, true, true);
 
-	// stft returns a vector of shape [nfft, frames, batch, 2] where the final shape (2) separates the magnitude and the phase
-	// kokoro concatenates the n_fft from the magnitude and the phase together so we have to split them up and concatenate
-	// along the n_fft axis
-	struct ggml_tensor * mhar  = ggml_cont(ctx, ggml_view_3d(ctx, har, har->ne[0], har->ne[1], har->ne[2], har->nb[1], har->nb[2], 0));
-	struct ggml_tensor * phhar = ggml_cont(ctx, ggml_view_3d(ctx, har, har->ne[0], har->ne[1], har->ne[2], har->nb[1], har->nb[2], har->nb[3]));
-	struct ggml_tensor * combined_har = ggml_cont(ctx, ggml_transpose(ctx, ggml_concat(ctx, mhar, phhar, 0)));
+  // stft returns a vector of shape [nfft, frames, batch, 2] where the final
+  // shape (2) separates the magnitude and the phase kokoro concatenates the
+  // n_fft from the magnitude and the phase together so we have to split them up
+  // and concatenate along the n_fft axis
+  struct ggml_tensor *mhar =
+      ggml_cont(ctx, ggml_view_3d(ctx, har, har->ne[0], har->ne[1], har->ne[2],
+                                  har->nb[1], har->nb[2], 0));
+  struct ggml_tensor *phhar =
+      ggml_cont(ctx, ggml_view_3d(ctx, har, har->ne[0], har->ne[1], har->ne[2],
+                                  har->nb[1], har->nb[2], har->nb[3]));
+  struct ggml_tensor *combined_har =
+      ggml_cont(ctx, ggml_transpose(ctx, ggml_concat(ctx, mhar, phhar, 0)));
 
-	struct ggml_tensor * cur = x;
-	for (int i = 0; i < generator->ups.size(); i++) {
-		cur = ggml_leaky_relu(ctx, cur, 0.1f, false);
-		cur = ggml_add(ctx, ggml_conv_transpose_1d(ctx, generator->ups[i]->upsample_weight, ggml_cont(ctx, ggml_transpose(ctx, cur)), generator->ups[i]->stride, generator->ups[i]->padding, 1, 0, 1), generator->ups[i]->upsample_bias);
-		if (i == generator->ups.size() - 1) {
-			// This is a hacky way of implementing the simple reflection padding used here. 
-			// In general, ggml should eventually be built to support expressive reflective padding but for such simple front padding this makes more sense.
-			struct ggml_tensor * temp = ggml_cont(ctx, ggml_view_3d(ctx, cur, 1, cur->ne[1], cur->ne[2], cur->nb[1], cur->nb[2], cur->nb[0]));
-			cur = ggml_concat(ctx, temp, cur, 0);
-		}
-		struct ggml_tensor * x_source = build_noise_block(ctx, generator->noise_blocks[i], ggml_cont(ctx, combined_har), style);
-		cur = ggml_add(ctx, cur, x_source);
-		struct ggml_tensor * x = cur;
-		for (int ii = 0; ii < model->n_kernels; ii++) {
-			if (ii == 0) {
-				cur = build_kokoro_generator_res_block(ctx, x, style, generator->res_blocks[i*model->n_kernels+ii]);
-			} else {
-				cur = ggml_add(ctx, cur, build_kokoro_generator_res_block(ctx, x, style, generator->res_blocks[i*model->n_kernels+ii]));
-			}
-		}
-		cur = ggml_cont(ctx, ggml_transpose(ctx, ggml_div(ctx, cur, model->n_kernels_tensor)));
-	}
+  struct ggml_tensor *cur = x;
+  for (int i = 0; i < generator->ups.size(); i++) {
+    cur = ggml_leaky_relu(ctx, cur, 0.1f, false);
+    cur =
+        ggml_add(ctx,
+                 ggml_conv_transpose_1d(
+                     ctx, generator->ups[i]->upsample_weight,
+                     ggml_cont(ctx, ggml_transpose(ctx, cur)),
+                     generator->ups[i]->stride, generator->ups[i]->padding, 1),
+                 generator->ups[i]->upsample_bias);
+    if (i == generator->ups.size() - 1) {
+      // This is a hacky way of implementing the simple reflection padding used
+      // here. In general, ggml should eventually be built to support expressive
+      // reflective padding but for such simple front padding this makes more
+      // sense.
+      struct ggml_tensor *temp =
+          ggml_cont(ctx, ggml_view_3d(ctx, cur, 1, cur->ne[1], cur->ne[2],
+                                      cur->nb[1], cur->nb[2], cur->nb[0]));
+      cur = ggml_concat(ctx, temp, cur, 0);
+    }
+    struct ggml_tensor *x_source = build_noise_block(
+        ctx, generator->noise_blocks[i], ggml_cont(ctx, combined_har), style);
+    cur = ggml_add(ctx, cur, x_source);
+    struct ggml_tensor *x = cur;
+    for (int ii = 0; ii < model->n_kernels; ii++) {
+      if (ii == 0) {
+        cur = build_kokoro_generator_res_block(
+            ctx, x, style, generator->res_blocks[i * model->n_kernels + ii]);
+      } else {
+        cur = ggml_add(ctx, cur,
+                       build_kokoro_generator_res_block(
+                           ctx, x, style,
+                           generator->res_blocks[i * model->n_kernels + ii]));
+      }
+    }
+    cur = ggml_cont(
+        ctx, ggml_transpose(ctx, ggml_div(ctx, cur, model->n_kernels_tensor)));
+  }
 
-	cur = ggml_leaky_relu(ctx, cur, 0.01f, false);
-	cur = ggml_add(ctx, ggml_conv_1d(ctx, generator->out_conv_weight, ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, model->out_conv_padding, 1), generator->out_conv_bias);
+  cur = ggml_leaky_relu(ctx, cur, 0.01f, false);
+  cur = ggml_add(ctx,
+                 ggml_conv_1d(ctx, generator->out_conv_weight,
+                              ggml_cont(ctx, ggml_transpose(ctx, cur)), 1,
+                              model->out_conv_padding, 1),
+                 generator->out_conv_bias);
 
-	struct ggml_tensor * spec = ggml_view_3d(ctx, cur, cur->ne[0], model->post_n_fft, cur->ne[2], cur->nb[1], cur->nb[2], 0);  
-	struct ggml_tensor * phase = ggml_view_3d(ctx, cur, cur->ne[0], cur->ne[1] - model->post_n_fft, cur->ne[2], cur->nb[1], cur->nb[2], cur->nb[1] * model->post_n_fft);  
-	phase = ggml_sin(ctx, phase);
-	spec = ggml_exp(ctx, spec);
+  struct ggml_tensor *spec =
+      ggml_view_3d(ctx, cur, cur->ne[0], model->post_n_fft, cur->ne[2],
+                   cur->nb[1], cur->nb[2], 0);
+  struct ggml_tensor *phase = ggml_view_3d(
+      ctx, cur, cur->ne[0], cur->ne[1] - model->post_n_fft, cur->ne[2],
+      cur->nb[1], cur->nb[2], cur->nb[1] * model->post_n_fft);
+  phase = ggml_sin(ctx, phase);
+  spec = ggml_exp(ctx, spec);
 
-	cur = ggml_concat(ctx, spec, phase, 3); // istft expects the magnitude and phase concatenated after the batch;
-	cur = istft(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)), window_sq_sum, generator->window, model->true_n_fft, model->stft_hop, true, true);
-	ggml_set_name(cur, "after_res_gen");
-	ggml_build_forward_expand(gf, cur);
-	return cur;
+  cur = ggml_concat(
+      ctx, spec, phase,
+      3); // istft expects the magnitude and phase concatenated after the batch;
+  cur =
+      istft(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)), window_sq_sum,
+            generator->window, model->true_n_fft, model->stft_hop, true, true);
+  ggml_set_name(cur, "after_res_gen");
+  ggml_build_forward_expand(gf, cur);
+  return cur;
 }
 
-static struct kokoro_generator_residual_block * build_res_block_from_file(gguf_context * meta, std::string base_config_key) {
-	struct kokoro_generator_residual_block * grb = new struct kokoro_generator_residual_block;
-	// these residual blocks always have 3 convolutional layers
-	for (int i = 0; i < 3; i++) {
-		grb->adain1d_1_gamma_weights.push_back(nullptr);
-		grb->adain1d_2_gamma_weights.push_back(nullptr);
-		grb->adain1d_1_gamma_biases.push_back(nullptr);
-		grb->adain1d_2_gamma_biases.push_back(nullptr);
-		grb->adain1d_1_beta_weights.push_back(nullptr);
-		grb->adain1d_2_beta_weights.push_back(nullptr);
-		grb->adain1d_1_beta_biases.push_back(nullptr);
-		grb->adain1d_2_beta_biases.push_back(nullptr);
-		grb->input_alphas.push_back(nullptr);
-		grb->output_alphas.push_back(nullptr);
-		grb->convs1_weights.push_back(nullptr);
-		grb->convs1_biases.push_back(nullptr);
-		grb->convs2_weights.push_back(nullptr);
-		grb->convs2_biases.push_back(nullptr);
-		int padding_key = gguf_find_key(meta, (base_config_key + "." + std::to_string(i) + ".padding").c_str());
-		int dilation_key = gguf_find_key(meta, (base_config_key + "." + std::to_string(i) + ".dilation").c_str());
-		if (padding_key == -1 || dilation_key == -1) {
-			TTS_ABORT("Could not find dilation and padding for generator residual block at key, '%s.%d'.", base_config_key.c_str(), i);
-		}
-		grb->conv1_dilations.push_back(gguf_get_val_u32(meta, dilation_key));
-		grb->conv1_paddings.push_back(gguf_get_val_u32(meta, padding_key));
-	}
-	return grb;
+static struct kokoro_generator_residual_block *
+build_res_block_from_file(gguf_context *meta, std::string base_config_key) {
+  struct kokoro_generator_residual_block *grb =
+      new struct kokoro_generator_residual_block;
+  // these residual blocks always have 3 convolutional layers
+  for (int i = 0; i < 3; i++) {
+    grb->adain1d_1_gamma_weights.push_back(nullptr);
+    grb->adain1d_2_gamma_weights.push_back(nullptr);
+    grb->adain1d_1_gamma_biases.push_back(nullptr);
+    grb->adain1d_2_gamma_biases.push_back(nullptr);
+    grb->adain1d_1_beta_weights.push_back(nullptr);
+    grb->adain1d_2_beta_weights.push_back(nullptr);
+    grb->adain1d_1_beta_biases.push_back(nullptr);
+    grb->adain1d_2_beta_biases.push_back(nullptr);
+    grb->input_alphas.push_back(nullptr);
+    grb->output_alphas.push_back(nullptr);
+    grb->convs1_weights.push_back(nullptr);
+    grb->convs1_biases.push_back(nullptr);
+    grb->convs2_weights.push_back(nullptr);
+    grb->convs2_biases.push_back(nullptr);
+    int padding_key = gguf_find_key(
+        meta, (base_config_key + "." + std::to_string(i) + ".padding").c_str());
+    int dilation_key = gguf_find_key(
+        meta,
+        (base_config_key + "." + std::to_string(i) + ".dilation").c_str());
+    if (padding_key == -1 || dilation_key == -1) {
+      TTS_ABORT("Could not find dilation and padding for generator residual "
+                "block at key, '%s.%d'.",
+                base_config_key.c_str(), i);
+    }
+    grb->conv1_dilations.push_back(gguf_get_val_u32(meta, dilation_key));
+    grb->conv1_paddings.push_back(gguf_get_val_u32(meta, padding_key));
+  }
+  return grb;
 }
 
-static struct kokoro_noise_residual_block * build_noise_block_from_file(gguf_context * meta, int index) {
-	struct kokoro_noise_residual_block * nb = new struct kokoro_noise_residual_block;
-	std::string base = "kokoro.decoder.generator.noise_blocks." + std::to_string(index);
-	nb->res_block = build_res_block_from_file(meta, base + ".res_block");
-	int stride_key = gguf_find_key(meta, (base + ".stride").c_str());
-	int padding_key = gguf_find_key(meta, (base + ".padding").c_str());
-	if (padding_key == -1 || stride_key == -1) {
-		TTS_ABORT("both padding and stride keys must be assigned in order to initialize a kokoro noise block.");
-	}
-	nb->input_conv_stride = gguf_get_val_u32(meta, stride_key);
-	nb->input_conv_padding = gguf_get_val_u32(meta, padding_key);
-	return nb;
+static struct kokoro_noise_residual_block *
+build_noise_block_from_file(gguf_context *meta, int index) {
+  struct kokoro_noise_residual_block *nb =
+      new struct kokoro_noise_residual_block;
+  std::string base =
+      "kokoro.decoder.generator.noise_blocks." + std::to_string(index);
+  nb->res_block = build_res_block_from_file(meta, base + ".res_block");
+  int stride_key = gguf_find_key(meta, (base + ".stride").c_str());
+  int padding_key = gguf_find_key(meta, (base + ".padding").c_str());
+  if (padding_key == -1 || stride_key == -1) {
+    TTS_ABORT("both padding and stride keys must be assigned in order to "
+              "initialize a kokoro noise block.");
+  }
+  nb->input_conv_stride = gguf_get_val_u32(meta, stride_key);
+  nb->input_conv_padding = gguf_get_val_u32(meta, padding_key);
+  return nb;
 }
 
-static struct kokoro_generator_upsample_block * kokoro_generator_upsample_block(gguf_context * meta, int index) {
-	struct kokoro_generator_upsample_block * usb = new struct kokoro_generator_upsample_block;
-	std::string base = "kokoro.decoder.generator.up_convs." + std::to_string(index);
-	int stride_key = gguf_find_key(meta, (base + ".stride").c_str());
-	int padding_key = gguf_find_key(meta, (base + ".padding").c_str());
-	if (padding_key == -1 || stride_key == -1) {
-		TTS_ABORT("both padding and stride keys must be assigned in order to initialize a kokoro upsample block.");
-	}
-	usb->stride = gguf_get_val_u32(meta, stride_key);
-	usb->padding = gguf_get_val_u32(meta, padding_key);
-	return usb;
+static struct kokoro_generator_upsample_block *
+kokoro_generator_upsample_block(gguf_context *meta, int index) {
+  struct kokoro_generator_upsample_block *usb =
+      new struct kokoro_generator_upsample_block;
+  std::string base =
+      "kokoro.decoder.generator.up_convs." + std::to_string(index);
+  int stride_key = gguf_find_key(meta, (base + ".stride").c_str());
+  int padding_key = gguf_find_key(meta, (base + ".padding").c_str());
+  if (padding_key == -1 || stride_key == -1) {
+    TTS_ABORT("both padding and stride keys must be assigned in order to "
+              "initialize a kokoro upsample block.");
+  }
+  usb->stride = gguf_get_val_u32(meta, stride_key);
+  usb->padding = gguf_get_val_u32(meta, padding_key);
+  return usb;
 }
 
 size_t kokoro_model::max_gen_nodes() {
-	return std::max<size_t>(8192, generation_node_counter*2);
+  return std::max<size_t>(8192, generation_node_counter * 2);
 }
 
 size_t kokoro_model::max_duration_nodes() {
-	return std::max<size_t>(8192, duration_node_counter*2);
+  return std::max<size_t>(8192, duration_node_counter * 2);
 }
 
 void kokoro_model::post_load_assign() {
-	size_t original_offset = offset;
-	n_kernels_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
-	n_kernels_tensor->buffer = buf;
-	n_kernels_tensor->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-	size_t size = ggml_nbytes(n_kernels_tensor);
-	float nker = (float) n_kernels;
-	ggml_backend_tensor_set(n_kernels_tensor, &nker, 0, size);
-	offset += size;
+  size_t original_offset = offset;
+  n_kernels_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+  n_kernels_tensor->buffer = buf;
+  n_kernels_tensor->data =
+      (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+  size_t size = ggml_nbytes(n_kernels_tensor);
+  float nker = (float)n_kernels;
+  ggml_backend_tensor_set(n_kernels_tensor, &nker, 0, size);
+  offset += size;
 
-	sqrt_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
-	sqrt_tensor->buffer = buf;
-   	sqrt_tensor->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-    size = ggml_nbytes(sqrt_tensor);
-    float sqrt2 = sqrtf(2.0f);
-	ggml_backend_tensor_set(sqrt_tensor, &sqrt2, 0, size);
-	offset += size;
+  sqrt_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+  sqrt_tensor->buffer = buf;
+  sqrt_tensor->data =
+      (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+  size = ggml_nbytes(sqrt_tensor);
+  float sqrt2 = sqrtf(2.0f);
+  ggml_backend_tensor_set(sqrt_tensor, &sqrt2, 0, size);
+  offset += size;
 
-	std::vector<float> data{};
-	for (int l = 0; l < lstms.size(); l++) {
-		lstm * rnn = lstms[l];
-		const int32_t hidden_size = rnn->cells[0]->biases[0]->ne[0];
-		data.resize(hidden_size);
+  std::vector<float> data{};
+  for (int l = 0; l < lstms.size(); l++) {
+    lstm *rnn = lstms[l];
+    const int32_t hidden_size = rnn->cells[0]->biases[0]->ne[0];
+    data.resize(hidden_size);
 
-		for (int i = 0; i < rnn->cells.size(); i++) {
-			struct ggml_tensor * h = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, hidden_size);
-			struct ggml_tensor * s = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, hidden_size);
-			h->buffer = buf;
-    		h->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-    		size_t size = ggml_nbytes(h);
-			ggml_backend_tensor_set(h, data.data(), 0, size);
-			ggml_format_name(h, "lstm%d_hidden", l);
-    		offset += size;
-			s->buffer = buf;
-    		s->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-			ggml_backend_tensor_set(s, data.data(), 0, size);
-			ggml_format_name(h, "lstm%d_state", l);
-    		offset += size;
-    		rnn->hidden.push_back(h);
-    		rnn->states.push_back(s);
-		}
-		data.clear();
-	}
+    for (int i = 0; i < rnn->cells.size(); i++) {
+      struct ggml_tensor *h =
+          ggml_new_tensor_1d(ctx, GGML_TYPE_F32, hidden_size);
+      struct ggml_tensor *s =
+          ggml_new_tensor_1d(ctx, GGML_TYPE_F32, hidden_size);
+      h->buffer = buf;
+      h->data = (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+      size_t size = ggml_nbytes(h);
+      ggml_backend_tensor_set(h, data.data(), 0, size);
+      ggml_format_name(h, "lstm%d_hidden", l);
+      offset += size;
+      s->buffer = buf;
+      s->data = (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+      ggml_backend_tensor_set(s, data.data(), 0, size);
+      ggml_format_name(h, "lstm%d_state", l);
+      offset += size;
+      rnn->hidden.push_back(h);
+      rnn->states.push_back(s);
+    }
+    data.clear();
+  }
 
-	if (window == "hann") {
-		std::vector<float> wdata;
-		wdata.reserve(true_n_fft);
-		hann_window(true_n_fft, wdata);
-		decoder->generator->window = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, true_n_fft);
-		decoder->generator->window->buffer = buf;
-		decoder->generator->window->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-		size_t size = ggml_nbytes(decoder->generator->window);
-		ggml_backend_tensor_set(decoder->generator->window, wdata.data(), 0, size);
-    	ggml_set_name(decoder->generator->window, "stft_window");
-    	offset += size;
-    	wdata.clear();
-	} else {
-		TTS_ABORT("Window of type %s is not supported.", window.c_str());
-	}
+  if (window == "hann") {
+    std::vector<float> wdata;
+    wdata.reserve(true_n_fft);
+    hann_window(true_n_fft, wdata);
+    decoder->generator->window =
+        ggml_new_tensor_1d(ctx, GGML_TYPE_F32, true_n_fft);
+    decoder->generator->window->buffer = buf;
+    decoder->generator->window->data =
+        (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+    size_t size = ggml_nbytes(decoder->generator->window);
+    ggml_backend_tensor_set(decoder->generator->window, wdata.data(), 0, size);
+    ggml_set_name(decoder->generator->window, "stft_window");
+    offset += size;
+    wdata.clear();
+  } else {
+    TTS_ABORT("Window of type %s is not supported.", window.c_str());
+  }
 
-	harmonic_sampling_norm = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, harmonic_num + 1);
-	harmonic_sampling_norm->buffer = buf;
-	harmonic_sampling_norm->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-	std::vector<float> hdata;
-	hdata.reserve(harmonic_num + 1);
-	for (int i = 0; i < harmonic_num + 1; i++) {
-		hdata.push_back(((float)i + 1.0f) / sample_rate);
-	}
-	size_t hsize = ggml_nbytes(harmonic_sampling_norm);
-	ggml_backend_tensor_set(harmonic_sampling_norm, hdata.data(), 0, hsize);
-	hdata.clear();
-	offset += hsize;
+  harmonic_sampling_norm =
+      ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, harmonic_num + 1);
+  harmonic_sampling_norm->buffer = buf;
+  harmonic_sampling_norm->data =
+      (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+  std::vector<float> hdata;
+  hdata.reserve(harmonic_num + 1);
+  for (int i = 0; i < harmonic_num + 1; i++) {
+    hdata.push_back(((float)i + 1.0f) / sample_rate);
+  }
+  size_t hsize = ggml_nbytes(harmonic_sampling_norm);
+  ggml_backend_tensor_set(harmonic_sampling_norm, hdata.data(), 0, hsize);
+  hdata.clear();
+  offset += hsize;
 
-	sampling_factor_scalar = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
-	sampling_factor_scalar->buffer = buf;
-   	sampling_factor_scalar->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-    size_t scsize = ggml_nbytes(sampling_factor_scalar);
-    // while it might appear that the upsampling_rate could be used here, the interpolation rate (i.e. the upsampling scale) is actually independent in the kokoro model implementation.
-    float sample_scalar = upsample_scale*2.0f*M_PI; 
-	ggml_backend_tensor_set(sampling_factor_scalar, &sample_scalar, 0, scsize);
-	offset += scsize;
-	post_load_tensor_bytes = 300 + offset - original_offset;
+  sampling_factor_scalar = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, 1);
+  sampling_factor_scalar->buffer = buf;
+  sampling_factor_scalar->data =
+      (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+  size_t scsize = ggml_nbytes(sampling_factor_scalar);
+  // while it might appear that the upsampling_rate could be used here, the
+  // interpolation rate (i.e. the upsampling scale) is actually independent in
+  // the kokoro model implementation.
+  float sample_scalar = upsample_scale * 2.0f * M_PI;
+  ggml_backend_tensor_set(sampling_factor_scalar, &sample_scalar, 0, scsize);
+  offset += scsize;
+  post_load_tensor_bytes = 300 + offset - original_offset;
 }
 
-void kokoro_model::assign_lstm(lstm * rnn, std::string name, ggml_tensor * tensor) {
-	std::vector<std::string> parts = split(name, ".");
-	int i = std::stoi(parts[0]);
-	int ii = std::stoi(parts[2]);
-	if (parts[1] == "weights") {
-		rnn->cells[i]->weights[ii] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(rnn->cells[i]->weights[ii], tensor);
-	} else if (parts[1] == "biases") {
-		rnn->cells[i]->biases[ii] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(rnn->cells[i]->biases[ii], tensor);
-	} else if (parts[1] == "reverse_weights") {
-		rnn->cells[i]->reverse_weights[ii] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(rnn->cells[i]->reverse_weights[ii], tensor);
-	} else if (parts[1] == "reverse_biases") {
-		rnn->cells[i]->reverse_biases[ii] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(rnn->cells[i]->reverse_biases[ii], tensor);
-	}
+void kokoro_model::assign_lstm(lstm *rnn, std::string name,
+                               ggml_tensor *tensor) {
+  std::vector<std::string> parts = split(name, ".");
+  int i = std::stoi(parts[0]);
+  int ii = std::stoi(parts[2]);
+  if (parts[1] == "weights") {
+    rnn->cells[i]->weights[ii] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(rnn->cells[i]->weights[ii], tensor);
+  } else if (parts[1] == "biases") {
+    rnn->cells[i]->biases[ii] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(rnn->cells[i]->biases[ii], tensor);
+  } else if (parts[1] == "reverse_weights") {
+    rnn->cells[i]->reverse_weights[ii] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(rnn->cells[i]->reverse_weights[ii], tensor);
+  } else if (parts[1] == "reverse_biases") {
+    rnn->cells[i]->reverse_biases[ii] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(rnn->cells[i]->reverse_biases[ii], tensor);
+  }
 }
 
-void kokoro_model::assign_weight(std::string name, ggml_tensor * tensor) {
-	// all kokoro tensors are prepended by "kokoro" so lets trim that off and assign based on the module
-	std::vector<std::string> parts = split(name, ".");
-	if (parts.size() < 2) {
-		return; // handle the null context tensor;
-	}
-	if (parts[1] == "albert") {
-		assign_albert_weight(name.substr(7+parts[1].size()+1), tensor);
-	} else if (parts[1] == "duration_predictor") {
-		assign_duration_weight(name.substr(7+parts[1].size()+1), tensor);
-	} else if (parts[1] == "text_encoder") {
-		assign_text_encoder_weight(name.substr(7+parts[1].size()+1), tensor);
-	} else if (parts[1] == "decoder") {
-		assign_decoder_weight(name.substr(7+parts[1].size()+1), tensor);
-	} else if (parts[1] == "voice_tensors") {
-		voices[parts[2]] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(voices[parts[2]], tensor);
-	}
+void kokoro_model::assign_weight(std::string name, ggml_tensor *tensor) {
+  // all kokoro tensors are prepended by "kokoro" so lets trim that off and
+  // assign based on the module
+  std::vector<std::string> parts = split(name, ".");
+  if (parts.size() < 2) {
+    return; // handle the null context tensor;
+  }
+  if (parts[1] == "albert") {
+    assign_albert_weight(name.substr(7 + parts[1].size() + 1), tensor);
+  } else if (parts[1] == "duration_predictor") {
+    assign_duration_weight(name.substr(7 + parts[1].size() + 1), tensor);
+  } else if (parts[1] == "text_encoder") {
+    assign_text_encoder_weight(name.substr(7 + parts[1].size() + 1), tensor);
+  } else if (parts[1] == "decoder") {
+    assign_decoder_weight(name.substr(7 + parts[1].size() + 1), tensor);
+  } else if (parts[1] == "voice_tensors") {
+    voices[parts[2]] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(voices[parts[2]], tensor);
+  }
 }
 
-void kokoro_model::assign_generator_weight(kokoro_generator * generator, std::string name, ggml_tensor * tensor) {
-	if (name == "m_source_weight") {
-		generator->m_source_weight = ggml_dup_tensor(ctx, tensor);
-		set_tensor(generator->m_source_weight, tensor);
-	} else if (name == "m_source_bias") {
-		generator->m_source_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(generator->m_source_bias, tensor);
-	} else if (name == "conv_post_weight") {
-		generator->out_conv_weight = ggml_dup_tensor(ctx, tensor);
-		set_tensor(generator->out_conv_weight, tensor);
-	} else if (name == "conv_post_bias") {
-		generator->out_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(generator->out_conv_bias, tensor);
-	} else {
-		std::vector<std::string> parts = split(name, ".");
-		int i = std::stoi(parts[1]);
-		if (parts[0] == "noise_blocks") {
-			if (parts[2] == "conv_weight") {
-				generator->noise_blocks[i]->input_conv = ggml_dup_tensor(ctx, tensor);
-				set_tensor(generator->noise_blocks[i]->input_conv, tensor);
-			} else if (parts[2] == "conv_bias") {
-				generator->noise_blocks[i]->input_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-				set_tensor(generator->noise_blocks[i]->input_conv_bias, tensor);
-			} else if (parts[2] == "resblock") {
-				assign_gen_resblock(generator->noise_blocks[i]->res_block, name.substr(parts[0].size()+parts[1].size()+parts[2].size()+3), tensor);
-			}
-		} else if (parts[0] == "resblocks") {
-			assign_gen_resblock(generator->res_blocks[i], name.substr(parts[0].size()+parts[1].size()+2), tensor);
-		} else if (parts[0] == "ups") {
-			if (parts[2] == "weight") {
-				generator->ups[i]->upsample_weight = ggml_dup_tensor(ctx, tensor);
-				set_tensor(generator->ups[i]->upsample_weight, tensor);
-			} else if (parts[2] == "bias") {
-				generator->ups[i]->upsample_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-				set_tensor(generator->ups[i]->upsample_bias, tensor);
-			}
-		}
-	}
+void kokoro_model::assign_generator_weight(kokoro_generator *generator,
+                                           std::string name,
+                                           ggml_tensor *tensor) {
+  if (name == "m_source_weight") {
+    generator->m_source_weight = ggml_dup_tensor(ctx, tensor);
+    set_tensor(generator->m_source_weight, tensor);
+  } else if (name == "m_source_bias") {
+    generator->m_source_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(generator->m_source_bias, tensor);
+  } else if (name == "conv_post_weight") {
+    generator->out_conv_weight = ggml_dup_tensor(ctx, tensor);
+    set_tensor(generator->out_conv_weight, tensor);
+  } else if (name == "conv_post_bias") {
+    generator->out_conv_bias =
+        ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(generator->out_conv_bias, tensor);
+  } else {
+    std::vector<std::string> parts = split(name, ".");
+    int i = std::stoi(parts[1]);
+    if (parts[0] == "noise_blocks") {
+      if (parts[2] == "conv_weight") {
+        generator->noise_blocks[i]->input_conv = ggml_dup_tensor(ctx, tensor);
+        set_tensor(generator->noise_blocks[i]->input_conv, tensor);
+      } else if (parts[2] == "conv_bias") {
+        generator->noise_blocks[i]->input_conv_bias =
+            ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+        set_tensor(generator->noise_blocks[i]->input_conv_bias, tensor);
+      } else if (parts[2] == "resblock") {
+        assign_gen_resblock(generator->noise_blocks[i]->res_block,
+                            name.substr(parts[0].size() + parts[1].size() +
+                                        parts[2].size() + 3),
+                            tensor);
+      }
+    } else if (parts[0] == "resblocks") {
+      assign_gen_resblock(generator->res_blocks[i],
+                          name.substr(parts[0].size() + parts[1].size() + 2),
+                          tensor);
+    } else if (parts[0] == "ups") {
+      if (parts[2] == "weight") {
+        generator->ups[i]->upsample_weight = ggml_dup_tensor(ctx, tensor);
+        set_tensor(generator->ups[i]->upsample_weight, tensor);
+      } else if (parts[2] == "bias") {
+        generator->ups[i]->upsample_bias =
+            ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+        set_tensor(generator->ups[i]->upsample_bias, tensor);
+      }
+    }
+  }
 }
 
-void kokoro_model::assign_gen_resblock(kokoro_generator_residual_block * block, std::string name, ggml_tensor * tensor) {
-	std::vector<std::string> parts = split(name, ".");
-	int i = std::stoi(parts[0]);
-	if (parts[1] == "gamma1_weight") {
-		block->adain1d_1_gamma_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_1_gamma_weights[i], tensor);
-	} else if (parts[1] == "gamma2_weight") {
-		block->adain1d_2_gamma_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_2_gamma_weights[i], tensor);
-	} else if (parts[1] == "gamma1_bias") {
-		block->adain1d_1_gamma_biases[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_1_gamma_biases[i], tensor);
-	} else if (parts[1] == "gamma2_bias") {
-		block->adain1d_2_gamma_biases[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_2_gamma_biases[i], tensor);		
-	} else if (parts[1] == "beta1_weight") {
-		block->adain1d_1_beta_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_1_beta_weights[i], tensor);
-	} else if (parts[1] == "beta2_weight") {
-		block->adain1d_2_beta_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_2_beta_weights[i], tensor);
-	} else if (parts[1] == "beta1_bias") {
-		block->adain1d_1_beta_biases[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_1_beta_biases[i], tensor);
-	} else if (parts[1] == "beta2_bias") {
-		block->adain1d_2_beta_biases[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->adain1d_2_beta_biases[i], tensor);		
-	} else if (parts[1] == "convs1_weight") {
-		block->convs1_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->convs1_weights[i], tensor);
-	} else if (parts[1] == "convs2_weight") {
-		block->convs2_weights[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->convs2_weights[i], tensor);
-	} else if (parts[1] == "convs1_bias") {
-		block->convs1_biases[i] = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->convs1_biases[i], tensor);
-	} else if (parts[1] == "convs2_bias") {
-		block->convs2_biases[i] = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->convs2_biases[i], tensor);		
-	} else if (parts[1] == "alpha1") {
-		block->input_alphas[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->input_alphas[i], tensor);
-	} else if (parts[1] == "alpha2") {
-		block->output_alphas[i] = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->output_alphas[i], tensor);		
-	}
+void kokoro_model::assign_gen_resblock(kokoro_generator_residual_block *block,
+                                       std::string name, ggml_tensor *tensor) {
+  std::vector<std::string> parts = split(name, ".");
+  int i = std::stoi(parts[0]);
+  if (parts[1] == "gamma1_weight") {
+    block->adain1d_1_gamma_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_1_gamma_weights[i], tensor);
+  } else if (parts[1] == "gamma2_weight") {
+    block->adain1d_2_gamma_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_2_gamma_weights[i], tensor);
+  } else if (parts[1] == "gamma1_bias") {
+    block->adain1d_1_gamma_biases[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_1_gamma_biases[i], tensor);
+  } else if (parts[1] == "gamma2_bias") {
+    block->adain1d_2_gamma_biases[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_2_gamma_biases[i], tensor);
+  } else if (parts[1] == "beta1_weight") {
+    block->adain1d_1_beta_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_1_beta_weights[i], tensor);
+  } else if (parts[1] == "beta2_weight") {
+    block->adain1d_2_beta_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_2_beta_weights[i], tensor);
+  } else if (parts[1] == "beta1_bias") {
+    block->adain1d_1_beta_biases[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_1_beta_biases[i], tensor);
+  } else if (parts[1] == "beta2_bias") {
+    block->adain1d_2_beta_biases[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->adain1d_2_beta_biases[i], tensor);
+  } else if (parts[1] == "convs1_weight") {
+    block->convs1_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->convs1_weights[i], tensor);
+  } else if (parts[1] == "convs2_weight") {
+    block->convs2_weights[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->convs2_weights[i], tensor);
+  } else if (parts[1] == "convs1_bias") {
+    block->convs1_biases[i] = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->convs1_biases[i], tensor);
+  } else if (parts[1] == "convs2_bias") {
+    block->convs2_biases[i] = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->convs2_biases[i], tensor);
+  } else if (parts[1] == "alpha1") {
+    block->input_alphas[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->input_alphas[i], tensor);
+  } else if (parts[1] == "alpha2") {
+    block->output_alphas[i] = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->output_alphas[i], tensor);
+  }
 }
 
-void kokoro_model::assign_ada_res_block(ada_residual_conv_block * block, std::string name, ggml_tensor * tensor) {
-	if (name == "norm1_gamma_weight") {
-		block->norm1_gamma = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm1_gamma, tensor);
-	} else if (name == "norm2_gamma_weight") {
-		block->norm2_gamma = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm2_gamma, tensor);
-	} else if (name == "norm1_gamma_bias") {
-		block->norm1_gamma_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm1_gamma_bias, tensor);
-	} else if (name == "norm2_gamma_bias") {
-		block->norm2_gamma_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm2_gamma_bias, tensor);		
-	} else if (name == "norm1_beta_weight") {
-		block->norm1_beta = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm1_beta, tensor);
-	} else if (name == "norm2_beta_weight") {
-		block->norm2_beta = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm2_beta, tensor);
-	} else if (name == "norm1_beta_bias") {
-		block->norm1_beta_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm1_beta_bias, tensor);
-	} else if (name == "norm2_beta_bias") {
-		block->norm2_beta_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->norm2_beta_bias, tensor);		
-	} else if (name == "conv1_weight") {
-		block->conv1 = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->conv1, tensor);
-	} else if (name == "conv2_weight") {
-		block->conv2 = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->conv2, tensor);
-	} else if (name == "conv1_bias") {
-		block->conv1_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->conv1_bias, tensor);
-	} else if (name == "conv2_bias") {
-		block->conv2_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->conv2_bias, tensor);		
-	} else if (name == "pool_weight") {
-		block->pool = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->pool, tensor);
-	} else if (name == "pool_bias") {
-		block->pool_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->pool_bias, tensor);		
-	} else if (name == "conv1x1_weight") {
-		block->upsample = ggml_dup_tensor(ctx, tensor);
-		set_tensor(block->upsample, tensor);
-	} else if (name == "conv1x1_bias") {
-		block->upsample_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(block->upsample_bias, tensor);		
-	}
+void kokoro_model::assign_ada_res_block(ada_residual_conv_block *block,
+                                        std::string name, ggml_tensor *tensor) {
+  if (name == "norm1_gamma_weight") {
+    block->norm1_gamma = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm1_gamma, tensor);
+  } else if (name == "norm2_gamma_weight") {
+    block->norm2_gamma = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm2_gamma, tensor);
+  } else if (name == "norm1_gamma_bias") {
+    block->norm1_gamma_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm1_gamma_bias, tensor);
+  } else if (name == "norm2_gamma_bias") {
+    block->norm2_gamma_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm2_gamma_bias, tensor);
+  } else if (name == "norm1_beta_weight") {
+    block->norm1_beta = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm1_beta, tensor);
+  } else if (name == "norm2_beta_weight") {
+    block->norm2_beta = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm2_beta, tensor);
+  } else if (name == "norm1_beta_bias") {
+    block->norm1_beta_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm1_beta_bias, tensor);
+  } else if (name == "norm2_beta_bias") {
+    block->norm2_beta_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->norm2_beta_bias, tensor);
+  } else if (name == "conv1_weight") {
+    block->conv1 = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->conv1, tensor);
+  } else if (name == "conv2_weight") {
+    block->conv2 = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->conv2, tensor);
+  } else if (name == "conv1_bias") {
+    block->conv1_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->conv1_bias, tensor);
+  } else if (name == "conv2_bias") {
+    block->conv2_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->conv2_bias, tensor);
+  } else if (name == "pool_weight") {
+    block->pool = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->pool, tensor);
+  } else if (name == "pool_bias") {
+    block->pool_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->pool_bias, tensor);
+  } else if (name == "conv1x1_weight") {
+    block->upsample = ggml_dup_tensor(ctx, tensor);
+    set_tensor(block->upsample, tensor);
+  } else if (name == "conv1x1_bias") {
+    block->upsample_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(block->upsample_bias, tensor);
+  }
 }
 
-void kokoro_model::assign_decoder_weight(std::string name, ggml_tensor * tensor) {
-	if (name == "f0_conv_weight") {
-		decoder->f0_conv = ggml_dup_tensor(ctx, tensor);
-		set_tensor(decoder->f0_conv, tensor);
-	} else if (name == "f0_conv_bias") {
-		decoder->f0_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(decoder->f0_conv_bias, tensor);
-	} else if (name == "n_conv_weight") {
-		decoder->n_conv = ggml_dup_tensor(ctx, tensor);
-		set_tensor(decoder->n_conv, tensor);
-	} else if (name == "n_conv_bias") {
-		decoder->n_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(decoder->n_conv_bias, tensor);
-	} else if (name == "asr_conv_weight") {
-		decoder->asr_conv = ggml_dup_tensor(ctx, tensor);
-		set_tensor(decoder->asr_conv, tensor);
-	} else if (name == "asr_conv_bias") {
-		decoder->asr_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(decoder->asr_conv_bias, tensor);
-	} else if (has_prefix(name, "decoder_blocks")) {
-		std::vector<std::string> parts = split(name, ".");
-		int i = std::stoi(parts[1]);
-		assign_ada_res_block(decoder->decoder_blocks[i], parts[2], tensor);
-	} else if (has_prefix(name, "encoder_block")) {
-		std::vector<std::string> parts = split(name, ".");
-		assign_ada_res_block(decoder->encoder_block, parts[1], tensor);
-	} else if (has_prefix(name, "generator")) {
-		assign_generator_weight(decoder->generator, name.substr(10), tensor);
-	}
+void kokoro_model::assign_decoder_weight(std::string name,
+                                         ggml_tensor *tensor) {
+  if (name == "f0_conv_weight") {
+    decoder->f0_conv = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->f0_conv, tensor);
+  } else if (name == "f0_conv_bias") {
+    decoder->f0_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(decoder->f0_conv_bias, tensor);
+  } else if (name == "n_conv_weight") {
+    decoder->n_conv = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->n_conv, tensor);
+  } else if (name == "n_conv_bias") {
+    decoder->n_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(decoder->n_conv_bias, tensor);
+  } else if (name == "asr_conv_weight") {
+    decoder->asr_conv = ggml_dup_tensor(ctx, tensor);
+    set_tensor(decoder->asr_conv, tensor);
+  } else if (name == "asr_conv_bias") {
+    decoder->asr_conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(decoder->asr_conv_bias, tensor);
+  } else if (has_prefix(name, "decoder_blocks")) {
+    std::vector<std::string> parts = split(name, ".");
+    int i = std::stoi(parts[1]);
+    assign_ada_res_block(decoder->decoder_blocks[i], parts[2], tensor);
+  } else if (has_prefix(name, "encoder_block")) {
+    std::vector<std::string> parts = split(name, ".");
+    assign_ada_res_block(decoder->encoder_block, parts[1], tensor);
+  } else if (has_prefix(name, "generator")) {
+    assign_generator_weight(decoder->generator, name.substr(10), tensor);
+  }
 }
 
-void kokoro_model::assign_duration_weight(std::string name, ggml_tensor * tensor) {
-	if (name == "encode") {
-		prosody_pred->albert_encode = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->albert_encode , tensor);
-	} else if (name == "encode_bias") {
-		prosody_pred->albert_encode_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->albert_encode_bias, tensor);
-	} else if (name == "duration_proj") {
-		prosody_pred->duration_proj = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->duration_proj, tensor);
-	} else if (name == "duration_proj_bias") {
-		prosody_pred->duration_proj_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->duration_proj_bias, tensor);
-	} else if (name == "n_proj_kernel") {
-		prosody_pred->n_proj_kernel = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->n_proj_kernel, tensor);
-	} else if (name == "n_proj_bias") {
-		prosody_pred->n_proj_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(prosody_pred->n_proj_bias, tensor);
-	} else if (name == "f0_proj_kernel") {
-		prosody_pred->f0_proj_kernel = ggml_dup_tensor(ctx, tensor);
-		set_tensor(prosody_pred->f0_proj_kernel, tensor);
-	} else if (name == "f0_proj_bias") {
-		prosody_pred->f0_proj_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-		set_tensor(prosody_pred->f0_proj_bias, tensor);
-	} else {
-		std::vector<std::string> parts = split(name, ".");
-		if (parts[0] == "shared_lstm") {
-			assign_lstm(prosody_pred->shared_lstm, name.substr(parts[0].size()+1), tensor);
-		} else if (parts[0] == "duration_lstm") {
-			assign_lstm(prosody_pred->duration_proj_lstm, name.substr(parts[0].size()+1), tensor);
-		} else if (parts[0] == "f0_blocks") {
-			int i = std::stoi(parts[1]);
-			assign_ada_res_block(prosody_pred->f0_blocks[i], parts[2], tensor);
-		} else if (parts[0] == "n_blocks") {
-			int i = std::stoi(parts[1]);
-			assign_ada_res_block(prosody_pred->n_blocks[i], parts[2], tensor);
-		} else if (parts[0] == "layers") {
-			int i = std::stoi(parts[1]);
-			i = i / 2;
-			if (parts[2] == "gamma_weight") {
-				prosody_pred->layers[i]->ada_norm_gamma_weight = ggml_dup_tensor(ctx, tensor);
-				set_tensor(prosody_pred->layers[i]->ada_norm_gamma_weight , tensor);
-			} else if (parts[2] == "gamma_bias") {
-				prosody_pred->layers[i]->ada_norm_gamma_bias = ggml_dup_tensor(ctx, tensor);
-				set_tensor(prosody_pred->layers[i]->ada_norm_gamma_bias , tensor);
-			} else if (parts[2] == "beta_weight") {
-				prosody_pred->layers[i]->ada_norm_beta_weight = ggml_dup_tensor(ctx, tensor);
-				set_tensor(prosody_pred->layers[i]->ada_norm_beta_weight , tensor);
-			} else if (parts[2] == "beta_bias") {
-				prosody_pred->layers[i]->ada_norm_beta_bias = ggml_dup_tensor(ctx, tensor);
-				set_tensor(prosody_pred->layers[i]->ada_norm_beta_bias , tensor);
-			} else if (parts[2] == "lstm") {
-				assign_lstm(prosody_pred->layers[i]->rnn, name.substr(parts[0].size()+parts[1].size()+parts[2].size()+3), tensor);
-			}
-		}
-	}
+void kokoro_model::assign_duration_weight(std::string name,
+                                          ggml_tensor *tensor) {
+  if (name == "encode") {
+    prosody_pred->albert_encode = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->albert_encode, tensor);
+  } else if (name == "encode_bias") {
+    prosody_pred->albert_encode_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->albert_encode_bias, tensor);
+  } else if (name == "duration_proj") {
+    prosody_pred->duration_proj = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->duration_proj, tensor);
+  } else if (name == "duration_proj_bias") {
+    prosody_pred->duration_proj_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->duration_proj_bias, tensor);
+  } else if (name == "n_proj_kernel") {
+    prosody_pred->n_proj_kernel = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->n_proj_kernel, tensor);
+  } else if (name == "n_proj_bias") {
+    prosody_pred->n_proj_bias =
+        ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(prosody_pred->n_proj_bias, tensor);
+  } else if (name == "f0_proj_kernel") {
+    prosody_pred->f0_proj_kernel = ggml_dup_tensor(ctx, tensor);
+    set_tensor(prosody_pred->f0_proj_kernel, tensor);
+  } else if (name == "f0_proj_bias") {
+    prosody_pred->f0_proj_bias =
+        ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+    set_tensor(prosody_pred->f0_proj_bias, tensor);
+  } else {
+    std::vector<std::string> parts = split(name, ".");
+    if (parts[0] == "shared_lstm") {
+      assign_lstm(prosody_pred->shared_lstm, name.substr(parts[0].size() + 1),
+                  tensor);
+    } else if (parts[0] == "duration_lstm") {
+      assign_lstm(prosody_pred->duration_proj_lstm,
+                  name.substr(parts[0].size() + 1), tensor);
+    } else if (parts[0] == "f0_blocks") {
+      int i = std::stoi(parts[1]);
+      assign_ada_res_block(prosody_pred->f0_blocks[i], parts[2], tensor);
+    } else if (parts[0] == "n_blocks") {
+      int i = std::stoi(parts[1]);
+      assign_ada_res_block(prosody_pred->n_blocks[i], parts[2], tensor);
+    } else if (parts[0] == "layers") {
+      int i = std::stoi(parts[1]);
+      i = i / 2;
+      if (parts[2] == "gamma_weight") {
+        prosody_pred->layers[i]->ada_norm_gamma_weight =
+            ggml_dup_tensor(ctx, tensor);
+        set_tensor(prosody_pred->layers[i]->ada_norm_gamma_weight, tensor);
+      } else if (parts[2] == "gamma_bias") {
+        prosody_pred->layers[i]->ada_norm_gamma_bias =
+            ggml_dup_tensor(ctx, tensor);
+        set_tensor(prosody_pred->layers[i]->ada_norm_gamma_bias, tensor);
+      } else if (parts[2] == "beta_weight") {
+        prosody_pred->layers[i]->ada_norm_beta_weight =
+            ggml_dup_tensor(ctx, tensor);
+        set_tensor(prosody_pred->layers[i]->ada_norm_beta_weight, tensor);
+      } else if (parts[2] == "beta_bias") {
+        prosody_pred->layers[i]->ada_norm_beta_bias =
+            ggml_dup_tensor(ctx, tensor);
+        set_tensor(prosody_pred->layers[i]->ada_norm_beta_bias, tensor);
+      } else if (parts[2] == "lstm") {
+        assign_lstm(prosody_pred->layers[i]->rnn,
+                    name.substr(parts[0].size() + parts[1].size() +
+                                parts[2].size() + 3),
+                    tensor);
+      }
+    }
+  }
 }
 
-void kokoro_model::assign_text_encoder_weight(std::string name, ggml_tensor * tensor) {
-	if (name == "embedding_weight") {
-		text_encoder->embd = ggml_dup_tensor(ctx, tensor);
-		set_tensor(text_encoder->embd, tensor);
-	} else if (has_prefix(name, "lstm")) {
-		assign_lstm(text_encoder->out_lstm, name.substr(5), tensor);
-	} else if (has_prefix(name, "layers")) {
-		std::vector<std::string> parts = split(name, ".");
-		int i = std::stoi(parts[1]);
-		if (parts[2] == "gamma") {
-			text_encoder->conv_layers[i]->norm_gamma = ggml_dup_tensor(ctx, tensor);
-			set_tensor(text_encoder->conv_layers[i]->norm_gamma, tensor);
-		} else if (parts[2] == "beta") {
-			text_encoder->conv_layers[i]->norm_beta = ggml_dup_tensor(ctx, tensor);
-			set_tensor(text_encoder->conv_layers[i]->norm_beta, tensor);
-		} else if (parts[2] == "weight") {
-			text_encoder->conv_layers[i]->conv_weight = ggml_dup_tensor(ctx, tensor);
-			set_tensor(text_encoder->conv_layers[i]->conv_weight, tensor);
-		} else if (parts[2] == "bias") {
-			text_encoder->conv_layers[i]->conv_bias = ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
-			set_tensor(text_encoder->conv_layers[i]->conv_bias, tensor);
-		}
-	}
+void kokoro_model::assign_text_encoder_weight(std::string name,
+                                              ggml_tensor *tensor) {
+  if (name == "embedding_weight") {
+    text_encoder->embd = ggml_dup_tensor(ctx, tensor);
+    set_tensor(text_encoder->embd, tensor);
+  } else if (has_prefix(name, "lstm")) {
+    assign_lstm(text_encoder->out_lstm, name.substr(5), tensor);
+  } else if (has_prefix(name, "layers")) {
+    std::vector<std::string> parts = split(name, ".");
+    int i = std::stoi(parts[1]);
+    if (parts[2] == "gamma") {
+      text_encoder->conv_layers[i]->norm_gamma = ggml_dup_tensor(ctx, tensor);
+      set_tensor(text_encoder->conv_layers[i]->norm_gamma, tensor);
+    } else if (parts[2] == "beta") {
+      text_encoder->conv_layers[i]->norm_beta = ggml_dup_tensor(ctx, tensor);
+      set_tensor(text_encoder->conv_layers[i]->norm_beta, tensor);
+    } else if (parts[2] == "weight") {
+      text_encoder->conv_layers[i]->conv_weight = ggml_dup_tensor(ctx, tensor);
+      set_tensor(text_encoder->conv_layers[i]->conv_weight, tensor);
+    } else if (parts[2] == "bias") {
+      text_encoder->conv_layers[i]->conv_bias =
+          ggml_dup_tensor(ctx, ggml_transpose(ctx, tensor));
+      set_tensor(text_encoder->conv_layers[i]->conv_bias, tensor);
+    }
+  }
 }
 
-void kokoro_model::assign_albert_weight(std::string name, ggml_tensor * tensor) {
-	if (name == "embd") {
-		embd_hidden = ggml_dup_tensor(ctx, tensor);
-		set_tensor(embd_hidden, tensor);
-	} else if (name == "embd_bias") {
-		embd_hidden_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(embd_hidden_bias, tensor);
-	} else if (name == "token_embd") {
-		token_embd = ggml_dup_tensor(ctx, tensor);
-		set_tensor(token_embd, tensor);
-	} else if (name == "position_embd") {
-		position_embd = ggml_dup_tensor(ctx, tensor);
-		set_tensor(position_embd, tensor);
-	} else if (name == "norm") {
-		input_norm_weight = ggml_dup_tensor(ctx, tensor);
-		set_tensor(input_norm_weight, tensor);
-	} else if (name == "norm_bias") {
-		input_norm_bias = ggml_dup_tensor(ctx, tensor);
-		set_tensor(input_norm_bias, tensor);
-	} else if (name == "token_type_embd") {
-		static_token_type_values = ggml_dup_tensor(ctx, tensor);
-		set_tensor(static_token_type_values, tensor);
-	} else if (has_prefix(name, "layer")) {
-		std::vector<std::string> parts = split(name, '.');
-		int i = std::stoi(parts[1]);
-		if (parts[2] == "ffn") {
-			layers[i]->ffn = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->ffn, tensor);
-		} else if (parts[2] == "ffn_bias") {
-			layers[i]->ffn_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->ffn_bias, tensor);
-		} else if (parts[2] == "ffn_out") {
-			layers[i]->ffn_out = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->ffn_out, tensor);
-		} else if (parts[2] == "ffn_out_bias") {
-			layers[i]->ffn_out_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->ffn_out_bias, tensor);
-		} else if (parts[2] == "attn_norm") {
-			layers[i]->layer_output_norm_weight = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->layer_output_norm_weight, tensor);
-		} else if (parts[2] == "attn_norm_bias") {
-			layers[i]->layer_output_norm_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->layer_output_norm_bias, tensor);
-		} else if (parts[2] == "q") {
-			layers[i]->q = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->q, tensor);
-		} else if (parts[2] == "k") {
-			layers[i]->k = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->k, tensor);
-		} else if (parts[2] == "v") {
-			layers[i]->v = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->v, tensor);
-		} else if (parts[2] == "o") {
-			layers[i]->o = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->o, tensor);
-		}  else if (parts[2] == "q_bias") {
-			layers[i]->q_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->q_bias, tensor);
-		} else if (parts[2] == "k_bias") {
-			layers[i]->k_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->k_bias, tensor);
-		} else if (parts[2] == "v_bias") {
-			layers[i]->v_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->v_bias, tensor);
-		} else if (parts[2] == "o_bias") {
-			layers[i]->o_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->o_bias, tensor);
-		} else if (parts[2] == "ffn_norm") {
-			layers[i]->attn_norm_weight = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->attn_norm_weight, tensor);
-		} else if (parts[2] == "ffn_norm_bias") {
-			layers[i]->attn_norm_bias = ggml_dup_tensor(ctx, tensor);
-			set_tensor(layers[i]->attn_norm_bias, tensor);
-		}
-	}
+void kokoro_model::assign_albert_weight(std::string name, ggml_tensor *tensor) {
+  if (name == "embd") {
+    embd_hidden = ggml_dup_tensor(ctx, tensor);
+    set_tensor(embd_hidden, tensor);
+  } else if (name == "embd_bias") {
+    embd_hidden_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(embd_hidden_bias, tensor);
+  } else if (name == "token_embd") {
+    token_embd = ggml_dup_tensor(ctx, tensor);
+    set_tensor(token_embd, tensor);
+  } else if (name == "position_embd") {
+    position_embd = ggml_dup_tensor(ctx, tensor);
+    set_tensor(position_embd, tensor);
+  } else if (name == "norm") {
+    input_norm_weight = ggml_dup_tensor(ctx, tensor);
+    set_tensor(input_norm_weight, tensor);
+  } else if (name == "norm_bias") {
+    input_norm_bias = ggml_dup_tensor(ctx, tensor);
+    set_tensor(input_norm_bias, tensor);
+  } else if (name == "token_type_embd") {
+    static_token_type_values = ggml_dup_tensor(ctx, tensor);
+    set_tensor(static_token_type_values, tensor);
+  } else if (has_prefix(name, "layer")) {
+    std::vector<std::string> parts = split(name, '.');
+    int i = std::stoi(parts[1]);
+    if (parts[2] == "ffn") {
+      layers[i]->ffn = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->ffn, tensor);
+    } else if (parts[2] == "ffn_bias") {
+      layers[i]->ffn_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->ffn_bias, tensor);
+    } else if (parts[2] == "ffn_out") {
+      layers[i]->ffn_out = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->ffn_out, tensor);
+    } else if (parts[2] == "ffn_out_bias") {
+      layers[i]->ffn_out_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->ffn_out_bias, tensor);
+    } else if (parts[2] == "attn_norm") {
+      layers[i]->layer_output_norm_weight = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->layer_output_norm_weight, tensor);
+    } else if (parts[2] == "attn_norm_bias") {
+      layers[i]->layer_output_norm_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->layer_output_norm_bias, tensor);
+    } else if (parts[2] == "q") {
+      layers[i]->q = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->q, tensor);
+    } else if (parts[2] == "k") {
+      layers[i]->k = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->k, tensor);
+    } else if (parts[2] == "v") {
+      layers[i]->v = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->v, tensor);
+    } else if (parts[2] == "o") {
+      layers[i]->o = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->o, tensor);
+    } else if (parts[2] == "q_bias") {
+      layers[i]->q_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->q_bias, tensor);
+    } else if (parts[2] == "k_bias") {
+      layers[i]->k_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->k_bias, tensor);
+    } else if (parts[2] == "v_bias") {
+      layers[i]->v_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->v_bias, tensor);
+    } else if (parts[2] == "o_bias") {
+      layers[i]->o_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->o_bias, tensor);
+    } else if (parts[2] == "ffn_norm") {
+      layers[i]->attn_norm_weight = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->attn_norm_weight, tensor);
+    } else if (parts[2] == "ffn_norm_bias") {
+      layers[i]->attn_norm_bias = ggml_dup_tensor(ctx, tensor);
+      set_tensor(layers[i]->attn_norm_bias, tensor);
+    }
+  }
 }
 
-lstm * kokoro_model::prep_lstm() {
-	lstm * rnn = new lstm;
-	lstm_cell * cell = new lstm_cell;
-	for (int i = 0; i < 8; i++) {
-		cell->weights.push_back(nullptr);
-		cell->biases.push_back(nullptr);
-		cell->reverse_weights.push_back(nullptr);
-		cell->reverse_biases.push_back(nullptr);
-	}
-	rnn->cells.push_back(cell);
-	rnn->bidirectional = true;
-	lstms.push_back(rnn);
-	return rnn;
+lstm *kokoro_model::prep_lstm() {
+  lstm *rnn = new lstm;
+  lstm_cell *cell = new lstm_cell;
+  for (int i = 0; i < 8; i++) {
+    cell->weights.push_back(nullptr);
+    cell->biases.push_back(nullptr);
+    cell->reverse_weights.push_back(nullptr);
+    cell->reverse_biases.push_back(nullptr);
+  }
+  rnn->cells.push_back(cell);
+  rnn->bidirectional = true;
+  lstms.push_back(rnn);
+  return rnn;
 }
 
-void kokoro_model::prep_layers(gguf_context * meta) {
-	prosody_pred = new duration_predictor;
-	prosody_pred->shared_lstm = prep_lstm();
-	prosody_pred->duration_proj_lstm = prep_lstm();
-	text_encoder = new kokoro_text_encoder;
-	decoder = new kokoro_decoder;
-	decoder->generator = new kokoro_generator;
-	decoder->encoder_block = new ada_residual_conv_block;
-	text_encoder->out_lstm = prep_lstm();
+void kokoro_model::prep_layers(gguf_context *meta) {
+  prosody_pred = new duration_predictor;
+  prosody_pred->shared_lstm = prep_lstm();
+  prosody_pred->duration_proj_lstm = prep_lstm();
+  text_encoder = new kokoro_text_encoder;
+  decoder = new kokoro_decoder;
+  decoder->generator = new kokoro_generator;
+  decoder->encoder_block = new ada_residual_conv_block;
+  text_encoder->out_lstm = prep_lstm();
 
-	for (int i = 0; i < n_layers; i++) {
-		layers.push_back(new albert_layer);
-	}
+  for (int i = 0; i < n_layers; i++) {
+    layers.push_back(new albert_layer);
+  }
 
-	for (int i = 0; i < f0_n_blocks; i++) {
-		ada_residual_conv_block * f0 = new ada_residual_conv_block;
-		ada_residual_conv_block * n = new ada_residual_conv_block;
-		prosody_pred->f0_blocks.push_back(f0);
-		prosody_pred->n_blocks.push_back(n);
-	}
+  for (int i = 0; i < f0_n_blocks; i++) {
+    ada_residual_conv_block *f0 = new ada_residual_conv_block;
+    ada_residual_conv_block *n = new ada_residual_conv_block;
+    prosody_pred->f0_blocks.push_back(f0);
+    prosody_pred->n_blocks.push_back(n);
+  }
 
-	for (int i = 0; i < n_duration_prediction_layers; i++) {
-		duration_predictor_layer* dpl = new duration_predictor_layer;
-		dpl->rnn = prep_lstm();
-		prosody_pred->layers.push_back(dpl);
-	}
+  for (int i = 0; i < n_duration_prediction_layers; i++) {
+    duration_predictor_layer *dpl = new duration_predictor_layer;
+    dpl->rnn = prep_lstm();
+    prosody_pred->layers.push_back(dpl);
+  }
 
-	for (int i = 0; i < n_decoder_blocks; i++) {
-		decoder->decoder_blocks.push_back(new ada_residual_conv_block);
-	}
+  for (int i = 0; i < n_decoder_blocks; i++) {
+    decoder->decoder_blocks.push_back(new ada_residual_conv_block);
+  }
 
-	for (int i = 0; i < n_noise_blocks; i++) {
-		struct kokoro_noise_residual_block * nb = build_noise_block_from_file(meta, i);
-		decoder->generator->noise_blocks.push_back(nb);
-	}
+  for (int i = 0; i < n_noise_blocks; i++) {
+    struct kokoro_noise_residual_block *nb =
+        build_noise_block_from_file(meta, i);
+    decoder->generator->noise_blocks.push_back(nb);
+  }
 
-	for (int i = 0; i < n_upsamples; i++) {
-		struct kokoro_generator_upsample_block * ub = kokoro_generator_upsample_block(meta, i);
-		decoder->generator->ups.push_back(ub);
-	}
+  for (int i = 0; i < n_upsamples; i++) {
+    struct kokoro_generator_upsample_block *ub =
+        kokoro_generator_upsample_block(meta, i);
+    decoder->generator->ups.push_back(ub);
+  }
 
-	for (int i = 0; i < n_res_blocks; i++) {
-		struct kokoro_generator_residual_block* rb = build_res_block_from_file(meta, "kokoro.decoder.generator.res_blocks." + std::to_string(i));
-		decoder->generator->res_blocks.push_back(rb);
-	}
+  for (int i = 0; i < n_res_blocks; i++) {
+    struct kokoro_generator_residual_block *rb = build_res_block_from_file(
+        meta, "kokoro.decoder.generator.res_blocks." + std::to_string(i));
+    decoder->generator->res_blocks.push_back(rb);
+  }
 
-	for (int i = 0; i < n_conv_layers; i++) {
-		text_encoder->conv_layers.push_back(new kokoro_text_encoder_conv_layer);
-	}
+  for (int i = 0; i < n_conv_layers; i++) {
+    text_encoder->conv_layers.push_back(new kokoro_text_encoder_conv_layer);
+  }
 }
 
-void kokoro_model::prep_constants(gguf_context * meta) {
-	// get constants for the Albert duration prediction model
-	int context_size_key = gguf_find_key(meta, "kokoro.duration_predictor.albert.context_length");
-    if (context_size_key != -1) {
-        max_context_length = gguf_get_val_u32(meta, context_size_key);;
-    }
+void kokoro_model::prep_constants(gguf_context *meta) {
+  // get constants for the Albert duration prediction model
+  int context_size_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.albert.context_length");
+  if (context_size_key != -1) {
+    max_context_length = gguf_get_val_u32(meta, context_size_key);
+    ;
+  }
 
-    int vocab_size_key = gguf_find_key(meta, "kokoro.tokenizer.vocab_size");
-    if (vocab_size_key != -1) {
-        vocab_size = gguf_get_val_u32(meta, vocab_size_key);
-    }
-    
-    int hidden_size_key = gguf_find_key(meta, "kokoro.duration_predictor.albert.hidden_size");
-    if (hidden_size_key != -1) {
-        hidden_size = gguf_get_val_u32(meta, hidden_size_key);
-    }
+  int vocab_size_key = gguf_find_key(meta, "kokoro.tokenizer.vocab_size");
+  if (vocab_size_key != -1) {
+    vocab_size = gguf_get_val_u32(meta, vocab_size_key);
+  }
 
-    int attn_heads_key = gguf_find_key(meta, "kokoro.duration_predictor.albert.attn_heads");
-    if (attn_heads_key != -1) {
-        n_attn_heads = gguf_get_val_u32(meta, attn_heads_key);
-        head_size = (uint32_t) hidden_size / n_attn_heads;
-    }
+  int hidden_size_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.albert.hidden_size");
+  if (hidden_size_key != -1) {
+    hidden_size = gguf_get_val_u32(meta, hidden_size_key);
+  }
 
-    int albert_layers_key = gguf_find_key(meta, "kokoro.duration_predictor.albert.layers");
-    if (albert_layers_key != -1) {
-        n_layers = gguf_get_val_u32(meta, albert_layers_key);
-    }
+  int attn_heads_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.albert.attn_heads");
+  if (attn_heads_key != -1) {
+    n_attn_heads = gguf_get_val_u32(meta, attn_heads_key);
+    head_size = (uint32_t)hidden_size / n_attn_heads;
+  }
 
-    int recurrence_key = gguf_find_key(meta, "kokoro.duration_predictor.albert.recurrence");
-    if (recurrence_key != -1) {
-        n_recurrence = gguf_get_val_u32(meta, recurrence_key);
-    }
+  int albert_layers_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.albert.layers");
+  if (albert_layers_key != -1) {
+    n_layers = gguf_get_val_u32(meta, albert_layers_key);
+  }
 
-    int duration_hidden_key = gguf_find_key(meta, "kokoro.duration_predictor.hidden_size");
-    if (duration_hidden_key != -1) {
-        duration_hidden_size = gguf_get_val_u32(meta, duration_hidden_key);
-    }
+  int recurrence_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.albert.recurrence");
+  if (recurrence_key != -1) {
+    n_recurrence = gguf_get_val_u32(meta, recurrence_key);
+  }
 
-    int up_sampling_factor_key = gguf_find_key(meta, "kokoro.decoder.generator.up_sampling_factor");
-    if (up_sampling_factor_key != -1) {
-        up_sampling_factor = gguf_get_val_u32(meta, up_sampling_factor_key);
-    }
+  int duration_hidden_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.hidden_size");
+  if (duration_hidden_key != -1) {
+    duration_hidden_size = gguf_get_val_u32(meta, duration_hidden_key);
+  }
 
-	int f0_n_blocks_key = gguf_find_key(meta, "kokoro.duration_predictor.f0_n_blocks");
-    if (f0_n_blocks_key != -1) {
-        f0_n_blocks = gguf_get_val_u32(meta, f0_n_blocks_key);
-    }
+  int up_sampling_factor_key =
+      gguf_find_key(meta, "kokoro.decoder.generator.up_sampling_factor");
+  if (up_sampling_factor_key != -1) {
+    up_sampling_factor = gguf_get_val_u32(meta, up_sampling_factor_key);
+  }
 
-   	int duration_pred_layers_key = gguf_find_key(meta, "kokoro.duration_predictor.layers");
-    if (duration_pred_layers_key != -1) {
-        n_duration_prediction_layers = gguf_get_val_u32(meta, duration_pred_layers_key);
-    }
+  int f0_n_blocks_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.f0_n_blocks");
+  if (f0_n_blocks_key != -1) {
+    f0_n_blocks = gguf_get_val_u32(meta, f0_n_blocks_key);
+  }
 
-	// get text and decoding configuration for generation
-	int n_conv_layers_key = gguf_find_key(meta, "kokoro.text_encoder.layers");
-    if (n_conv_layers_key != -1) {
-        n_conv_layers = gguf_get_val_u32(meta, n_conv_layers_key);
-    }
+  int duration_pred_layers_key =
+      gguf_find_key(meta, "kokoro.duration_predictor.layers");
+  if (duration_pred_layers_key != -1) {
+    n_duration_prediction_layers =
+        gguf_get_val_u32(meta, duration_pred_layers_key);
+  }
 
-   	int n_kernels_key = gguf_find_key(meta, "kokoro.decoder.generator.kernels");
-    if (n_kernels_key != -1) {
-        n_kernels = gguf_get_val_u32(meta, n_kernels_key);
-    }
+  // get text and decoding configuration for generation
+  int n_conv_layers_key = gguf_find_key(meta, "kokoro.text_encoder.layers");
+  if (n_conv_layers_key != -1) {
+    n_conv_layers = gguf_get_val_u32(meta, n_conv_layers_key);
+  }
 
-    int n_upsamples_key = gguf_find_key(meta, "kokoro.decoder.generator.upsamples");
-    if (n_upsamples_key != -1) {
-        n_upsamples = gguf_get_val_u32(meta, n_upsamples_key);
-    }
+  int n_kernels_key = gguf_find_key(meta, "kokoro.decoder.generator.kernels");
+  if (n_kernels_key != -1) {
+    n_kernels = gguf_get_val_u32(meta, n_kernels_key);
+  }
 
-    int n_decoder_blocks_key = gguf_find_key(meta, "kokoro.decoder.generator.layers");
-    if (n_decoder_blocks_key != -1) {
-        n_decoder_blocks = gguf_get_val_u32(meta, n_decoder_blocks_key);
-    }
+  int n_upsamples_key =
+      gguf_find_key(meta, "kokoro.decoder.generator.upsamples");
+  if (n_upsamples_key != -1) {
+    n_upsamples = gguf_get_val_u32(meta, n_upsamples_key);
+  }
 
-    int out_conv_padding_key = gguf_find_key(meta, "kokoro.decoder.generator.padding");
-    if (out_conv_padding_key != -1) {
-        out_conv_padding = gguf_get_val_u32(meta, out_conv_padding_key);
-    }
+  int n_decoder_blocks_key =
+      gguf_find_key(meta, "kokoro.decoder.generator.layers");
+  if (n_decoder_blocks_key != -1) {
+    n_decoder_blocks = gguf_get_val_u32(meta, n_decoder_blocks_key);
+  }
 
-    int n_fft_key = gguf_find_key(meta, "kokoro.decoder.generator.n_fft");
-    if (n_fft_key != -1) {
-        true_n_fft = gguf_get_val_u32(meta, n_fft_key);
-        post_n_fft = (uint32_t) true_n_fft / 2 + 1;
-    }
+  int out_conv_padding_key =
+      gguf_find_key(meta, "kokoro.decoder.generator.padding");
+  if (out_conv_padding_key != -1) {
+    out_conv_padding = gguf_get_val_u32(meta, out_conv_padding_key);
+  }
 
-    int stft_hop_key = gguf_find_key(meta, "kokoro.decoder.generator.hop");
-    if (stft_hop_key != -1) {
-        stft_hop = gguf_get_val_u32(meta, stft_hop_key);
-    }
+  int n_fft_key = gguf_find_key(meta, "kokoro.decoder.generator.n_fft");
+  if (n_fft_key != -1) {
+    true_n_fft = gguf_get_val_u32(meta, n_fft_key);
+    post_n_fft = (uint32_t)true_n_fft / 2 + 1;
+  }
+
+  int stft_hop_key = gguf_find_key(meta, "kokoro.decoder.generator.hop");
+  if (stft_hop_key != -1) {
+    stft_hop = gguf_get_val_u32(meta, stft_hop_key);
+  }
 }
 
 kokoro_ubatch kokoro_duration_runner::build_worst_case_batch() {
-	kokoro_ubatch batch;
-	batch.n_tokens = model->max_context_length;
-	return batch;
+  kokoro_ubatch batch;
+  batch.n_tokens = model->max_context_length;
+  return batch;
 }
 
-struct ggml_cgraph * kokoro_duration_runner::build_kokoro_duration_graph(kokoro_ubatch & batch) {
-    init_build();
-    // This '110000' number is coming from the number of nodes necessary for the longest possible sequence computed by of the graph.
-    // While it may be possible to precompute this by determining the longest possible duration against he maximum context length of the model,
-    // it is not easily performed given that nodes do not necessarily line up predictably with the number of tensors in the model or its submodels.
-    // In order to side step this problem I computed the graph and determined the size in advance and use that constant value here.
-    struct ggml_cgraph * gf = ggml_new_graph_custom(ctx, 110000, false);
+struct ggml_cgraph *
+kokoro_duration_runner::build_kokoro_duration_graph(kokoro_ubatch &batch) {
+  init_build();
+  // This '110000' number is coming from the number of nodes necessary for the
+  // longest possible sequence computed by of the graph. While it may be
+  // possible to precompute this by determining the longest possible duration
+  // against he maximum context length of the model, it is not easily performed
+  // given that nodes do not necessarily line up predictably with the number of
+  // tensors in the model or its submodels. In order to side step this problem I
+  // computed the graph and determined the size in advance and use that constant
+  // value here.
+  struct ggml_cgraph *gf = ggml_new_graph_custom(ctx, 110000, false);
 
-    struct ggml_tensor * voice = model->voices[kctx->voice];
-    struct ggml_tensor * cur;
-    struct ggml_tensor * inpL;
+  struct ggml_tensor *voice = model->voices[kctx->voice];
+  struct ggml_tensor *cur;
+  struct ggml_tensor *inpL;
 
-    kctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
-    ggml_set_input(kctx->inp_tokens);
+  kctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
+  ggml_set_input(kctx->inp_tokens);
 
-    if (!model->static_token_types) {
-    	kctx->token_types = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
-    	ggml_set_input(kctx->token_types);
+  if (!model->static_token_types) {
+    kctx->token_types = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
+    ggml_set_input(kctx->token_types);
+  }
+
+  kctx->positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
+  ggml_set_input(kctx->positions);
+
+  inpL = build_albert_inputs(ctx, model, kctx->inp_tokens, kctx->positions,
+                             kctx->token_types);
+  ggml_set_name(inpL, "albert_embeddings");
+  cur = inpL;
+
+  struct ggml_tensor *KQ_mask_dec = build_albert_attn_mask(ctx, kctx, batch);
+
+  for (int r = 0; r < model->n_recurrence; r++) {
+    for (int l = 0; l < model->n_layers; l++) {
+      struct ggml_tensor *residual = cur;
+      struct ggml_tensor *attn_out;
+
+      // self-attention
+      {
+        struct ggml_tensor *Qcur =
+            ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->q, cur),
+                     model->layers[l]->q_bias);
+        struct ggml_tensor *Kcur =
+            ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->k, cur),
+                     model->layers[l]->k_bias);
+        struct ggml_tensor *Vcur =
+            ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->v, cur),
+                     model->layers[l]->v_bias);
+
+        Qcur = ggml_reshape_3d(ctx, Qcur, model->head_size, model->n_attn_heads,
+                               batch.n_tokens);
+        Kcur = ggml_reshape_3d(ctx, Kcur, model->head_size, model->n_attn_heads,
+                               batch.n_tokens);
+
+        struct ggml_tensor *q = ggml_permute(ctx, Qcur, 0, 2, 1, 3);
+        struct ggml_tensor *k =
+            ggml_cont(ctx, ggml_permute(ctx, Kcur, 0, 2, 1, 3));
+        struct ggml_tensor *kq = ggml_mul_mat(ctx, k, q);
+
+        kq = ggml_soft_max_ext(ctx, kq, KQ_mask_dec, model->scale, 0.0f);
+
+        struct ggml_tensor *v =
+            ggml_cont_3d(ctx, ggml_transpose(ctx, Vcur), batch.n_tokens,
+                         model->head_size, model->n_attn_heads);
+        struct ggml_tensor *kqv = ggml_mul_mat(ctx, kq, v);
+        struct ggml_tensor *kqv_merged = ggml_permute(ctx, kqv, 2, 0, 1, 3);
+        attn_out =
+            ggml_cont_2d(ctx, kqv_merged, model->hidden_size, batch.n_tokens);
+        attn_out =
+            ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->o, attn_out),
+                     model->layers[l]->o_bias);
+      }
+      cur = ggml_add(ctx, attn_out, residual);
+      cur = build_albert_norm(ctx, cur, model->layers[l]->attn_norm_weight,
+                              model->layers[l]->attn_norm_bias);
+
+      struct ggml_tensor *residualffn = cur;
+
+      // ffn
+      {
+        cur = ggml_gelu(
+            ctx, ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->ffn, cur),
+                          model->layers[l]->ffn_bias));
+        cur = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->ffn_out, cur),
+                       model->layers[l]->ffn_out_bias);
+      }
+
+      cur = ggml_add(ctx, cur, residualffn);
+      cur = build_albert_norm(ctx, cur,
+                              model->layers[l]->layer_output_norm_weight,
+                              model->layers[l]->layer_output_norm_bias);
     }
+  }
 
-    kctx->positions = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
-    ggml_set_input(kctx->positions);
+  // duration / prosody prediction
+  cur =
+      ggml_add(ctx, ggml_mul_mat(ctx, model->prosody_pred->albert_encode, cur),
+               model->prosody_pred->albert_encode_bias);
 
-    inpL = build_albert_inputs(ctx, model, kctx->inp_tokens, kctx->positions, kctx->token_types);
-    ggml_set_name(inpL, "albert_embeddings");
-    cur = inpL;
+  struct ggml_tensor *style_half =
+      ggml_cont(ctx, ggml_view_1d(ctx, voice, voice->ne[0] / 2,
+                                  voice->ne[0] / 2 * voice->nb[0] +
+                                      (batch.n_tokens - 3) * voice->nb[1]));
 
-    struct ggml_tensor * KQ_mask_dec = build_albert_attn_mask(ctx, kctx, batch);
-    
-    for (int r = 0; r < model->n_recurrence; r++) {
-    	for (int l = 0; l < model->n_layers; l++) {
-	        struct ggml_tensor * residual = cur ;
-	        struct ggml_tensor * attn_out;
+  cur = ggml_concat(
+      ctx, cur,
+      ggml_repeat(ctx, style_half,
+                  ggml_new_tensor_2d(ctx, GGML_TYPE_F32, style_half->ne[0],
+                                     cur->ne[1])),
+      0);
 
-	        // self-attention
-	        {
-	            struct ggml_tensor * Qcur = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->q, cur), model->layers[l]->q_bias);
-	            struct ggml_tensor * Kcur = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->k, cur), model->layers[l]->k_bias);
-	            struct ggml_tensor * Vcur = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->v, cur), model->layers[l]->v_bias);
+  for (auto l : model->prosody_pred->layers) {
+    cur = build_lstm(ctx, cur, l->rnn, batch.n_tokens);
 
-				Qcur = ggml_reshape_3d(ctx, Qcur, model->head_size, model->n_attn_heads, batch.n_tokens);
-	            Kcur = ggml_reshape_3d(ctx, Kcur, model->head_size, model->n_attn_heads, batch.n_tokens);
+    struct ggml_tensor *gamma =
+        ggml_add(ctx, ggml_mul_mat(ctx, l->ada_norm_gamma_weight, style_half),
+                 l->ada_norm_gamma_bias);
+    struct ggml_tensor *beta =
+        ggml_add(ctx, ggml_mul_mat(ctx, l->ada_norm_beta_weight, style_half),
+                 l->ada_norm_beta_bias);
 
-	            struct ggml_tensor * q = ggml_permute(ctx, Qcur, 0, 2, 1, 3);
-	            struct ggml_tensor * k = ggml_cont(ctx, ggml_permute(ctx, Kcur, 0, 2, 1, 3));
-	            struct ggml_tensor * kq = ggml_mul_mat(ctx, k, q);
+    cur = ggml_norm(ctx, cur, 0.00001);
 
-	            kq = ggml_soft_max_ext(ctx, kq, KQ_mask_dec, model->scale, 0.0f);
+    // The addition between gamma * x and x is performed here because ggml
+    // doesn't support scalar multiplication without initializing the scalars in
+    // advance. An optimal remedy to this would be to increment the gamma bias
+    // above by one when preparing the gguf file for the model.
+    cur = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
+    cur = ggml_concat(
+        ctx, cur,
+        ggml_repeat(ctx, style_half,
+                    ggml_new_tensor_2d(ctx, GGML_TYPE_F32, style_half->ne[0],
+                                       cur->ne[1])),
+        0);
+    ggml_build_forward_expand(gf, cur);
+  }
 
-	            struct ggml_tensor * v = ggml_cont_3d(ctx, ggml_transpose(ctx, Vcur), batch.n_tokens, model->head_size, model->n_attn_heads);
-	            struct ggml_tensor * kqv = ggml_mul_mat(ctx, kq, v);
-	            struct ggml_tensor * kqv_merged = ggml_permute(ctx, kqv, 2, 0, 1, 3);
-	            attn_out = ggml_cont_2d(ctx, kqv_merged, model->hidden_size, batch.n_tokens);
-	            attn_out = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->o, attn_out), model->layers[l]->o_bias);
-	        }
-	        cur = ggml_add(ctx, attn_out, residual);
-	        cur = build_albert_norm(ctx, cur, model->layers[l]->attn_norm_weight, model->layers[l]->attn_norm_bias);
+  struct ggml_tensor *d = ggml_cont(ctx, cur);
+  ggml_set_name(d, "duration_hidden_states");
+  ggml_build_forward_expand(gf, d);
 
-	        struct ggml_tensor * residualffn = cur;
+  struct ggml_tensor *len;
+  cur = build_lstm(ctx, cur, model->prosody_pred->duration_proj_lstm,
+                   batch.n_tokens);
+  cur = ggml_sigmoid(
+      ctx,
+      ggml_add(ctx, ggml_mul_mat(ctx, model->prosody_pred->duration_proj, cur),
+               model->prosody_pred->duration_proj_bias));
+  // If we were to support speed we would add a constant tensor for the speed
+  // and divide here.
+  len = ggml_round(ctx, ggml_sum_rows(ctx, cur));
+  len = ggml_clamp(ctx, ggml_round(ctx, ggml_sum_rows(ctx, cur)), 1.0f, 50.0f);
 
-	        // ffn
-	        {
-	        	cur = ggml_gelu(ctx, ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->ffn, cur), model->layers[l]->ffn_bias));
-	        	cur = ggml_add(ctx, ggml_mul_mat(ctx, model->layers[l]->ffn_out, cur), model->layers[l]->ffn_out_bias);
-	        }
+  ggml_build_forward_expand(gf, len);
 
-			cur = ggml_add(ctx, cur, residualffn);
-			cur = build_albert_norm(ctx, cur, model->layers[l]->layer_output_norm_weight, model->layers[l]->layer_output_norm_bias);
-	    }
-    }
+  free_build();
 
-    // duration / prosody prediction
-    cur = ggml_add(ctx, ggml_mul_mat(ctx, model->prosody_pred->albert_encode, cur), model->prosody_pred->albert_encode_bias);
-
-	struct ggml_tensor * style_half = ggml_cont(ctx, ggml_view_1d(ctx, voice, voice->ne[0]/2, voice->ne[0] / 2 * voice->nb[0] + (batch.n_tokens - 3) * voice->nb[1]));
-
-	cur = ggml_concat(ctx, cur, ggml_repeat(ctx, style_half, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, style_half->ne[0], cur->ne[1])), 0);
-
-    for (auto l : model->prosody_pred->layers) {
-    	cur = build_lstm(ctx, cur, l->rnn, batch.n_tokens);
-
-    	struct ggml_tensor * gamma = ggml_add(ctx, ggml_mul_mat(ctx, l->ada_norm_gamma_weight, style_half), l->ada_norm_gamma_bias);
-    	struct ggml_tensor * beta = ggml_add(ctx, ggml_mul_mat(ctx, l->ada_norm_beta_weight, style_half), l->ada_norm_beta_bias);
-
-    	cur = ggml_norm(ctx, cur, 0.00001);
-
-    	// The addition between gamma * x and x is performed here because ggml doesn't support scalar multiplication without initializing the scalars in advance.
-		// An optimal remedy to this would be to increment the gamma bias above by one when preparing the gguf file for the model.
-    	cur = ggml_add(ctx, ggml_add(ctx, cur, ggml_mul(ctx, cur, gamma)), beta);
-    	cur = ggml_concat(ctx, cur, ggml_repeat(ctx, style_half, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, style_half->ne[0], cur->ne[1])), 0);
-		ggml_build_forward_expand(gf, cur);
-    }
-
-    struct ggml_tensor * d = ggml_cont(ctx, cur);
-    ggml_set_name(d, "duration_hidden_states");
-    ggml_build_forward_expand(gf, d);
-
-    struct ggml_tensor * len;
-    cur = build_lstm(ctx, cur, model->prosody_pred->duration_proj_lstm, batch.n_tokens);
-    cur = ggml_sigmoid(ctx, ggml_add(ctx, ggml_mul_mat(ctx, model->prosody_pred->duration_proj, cur), model->prosody_pred->duration_proj_bias));
-    // If we were to support speed we would add a constant tensor for the speed and divide here.
-    len = ggml_round(ctx, ggml_sum_rows(ctx, cur));
-    len = ggml_clamp(ctx, ggml_round(ctx, ggml_sum_rows(ctx, cur)), 1.0f, 50.0f);
-
-    ggml_build_forward_expand(gf, len);
-
-    free_build();
-    
-    return gf;
+  return gf;
 }
 
 void kokoro_duration_runner::prepare_post_load() {
-    auto batch = build_worst_case_batch();
-    auto gf = build_kokoro_duration_graph(batch);
-    kctx->prep_schedule(gf);
+  auto batch = build_worst_case_batch();
+  auto gf = build_kokoro_duration_graph(batch);
+  kctx->prep_schedule(gf);
 }
 
-void kokoro_duration_runner::set_inputs(kokoro_ubatch & batch) {
-	ggml_backend_tensor_set(kctx->inp_tokens, batch.input_tokens, 0, batch.n_tokens*ggml_element_size(kctx->inp_tokens));
-	uint32_t * positions_d = nullptr;
-    positions_d = (uint32_t *) kctx->positions->data;
-    float * attn_d = nullptr;
-    attn_d = (float *) kctx->attn_mask->data;
-	for (uint32_t i = 0; i < batch.n_tokens; i++) {
-        positions_d[i] =  i;
-        for (uint32_t ii = 0; ii < batch.n_tokens; ii++) {
-        	attn_d[i*batch.n_tokens + ii] = 0.0f; // Kokoro doesn't use causal attention as it isnt an autoregressive generative model;
-        }
+void kokoro_duration_runner::set_inputs(kokoro_ubatch &batch) {
+  ggml_backend_tensor_set(kctx->inp_tokens, batch.input_tokens, 0,
+                          batch.n_tokens * ggml_element_size(kctx->inp_tokens));
+  uint32_t *positions_d = nullptr;
+  positions_d = (uint32_t *)kctx->positions->data;
+  float *attn_d = nullptr;
+  attn_d = (float *)kctx->attn_mask->data;
+  for (uint32_t i = 0; i < batch.n_tokens; i++) {
+    positions_d[i] = i;
+    for (uint32_t ii = 0; ii < batch.n_tokens; ii++) {
+      attn_d[i * batch.n_tokens + ii] =
+          0.0f; // Kokoro doesn't use causal attention as it isnt an
+                // autoregressive generative model;
     }
+  }
 }
 
-void kokoro_duration_runner::run(kokoro_ubatch & batch) {
-    ggml_backend_sched_reset(kctx->sched);
+void kokoro_duration_runner::run(kokoro_ubatch &batch) {
+  ggml_backend_sched_reset(kctx->sched);
 
-    size_t prev_size = kctx->buf_output ? ggml_backend_buffer_get_size(kctx->buf_output) : 0;
-    size_t new_size = model->max_context_length * (model->duration_hidden_size + model->style_half_size) * sizeof(float);
+  size_t prev_size =
+      kctx->buf_output ? ggml_backend_buffer_get_size(kctx->buf_output) : 0;
+  size_t new_size = model->max_context_length *
+                    (model->duration_hidden_size + model->style_half_size) *
+                    sizeof(float);
 
-    if (!kctx->buf_output || prev_size < new_size) {
-	    if (kctx->buf_output) {
-	        ggml_backend_buffer_free(kctx->buf_output);
-	        kctx->buf_output = nullptr;
-	        kctx->logits = nullptr;
-	    }
-	    kctx->buf_output = ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
-	}
-
-    prev_size = kctx->buf_len_output ? ggml_backend_buffer_get_size(kctx->buf_len_output) : 0;
-    new_size = model->max_context_length * sizeof(float);
-    
-    if (!kctx->buf_len_output || prev_size < new_size) {
-        if (kctx->buf_output) {
-            ggml_backend_buffer_free(kctx->buf_len_output);
-            kctx->buf_len_output = nullptr;
-            kctx->lens = nullptr;
-        }
-
-        kctx->buf_len_output = ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
+  if (!kctx->buf_output || prev_size < new_size) {
+    if (kctx->buf_output) {
+      ggml_backend_buffer_free(kctx->buf_output);
+      kctx->buf_output = nullptr;
+      kctx->logits = nullptr;
     }
-    
-    
-    batch.resp->hidden_states = (float *) ggml_backend_buffer_get_base(kctx->buf_output);
-    ggml_backend_buffer_clear(kctx->buf_output, 0);
-    batch.resp->lengths = (float *) ggml_backend_buffer_get_base(kctx->buf_len_output);
-    ggml_backend_buffer_clear(kctx->buf_len_output, 0);
-    
-    struct ggml_cgraph * gf = NULL;
-    gf = build_kokoro_duration_graph(batch);
-    
-    // the output is always the last tensor in the graph
-    struct ggml_tensor * lens = gf->nodes[gf->n_nodes - 1];
-    // the reused duration hidden states are computed before a node chunk which has a size that is sequence length dependent
-    struct ggml_tensor * hidden_states = gf->nodes[gf->n_nodes - 22 - 52 * batch.n_tokens];
-    ggml_backend_sched_alloc_graph(kctx->sched, gf);
-    
-    set_inputs(batch);
+    kctx->buf_output =
+        ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
+  }
 
-    ggml_backend_sched_graph_compute_async(kctx->sched, gf);
+  prev_size = kctx->buf_len_output
+                  ? ggml_backend_buffer_get_size(kctx->buf_len_output)
+                  : 0;
+  new_size = model->max_context_length * sizeof(float);
 
-    kctx->get_ggml_node_data(lens, batch.resp->lengths, batch.n_tokens*sizeof(float), kctx->buf_len_output);
-    kctx->get_ggml_node_data(hidden_states, batch.resp->hidden_states, batch.n_tokens*(model->duration_hidden_size+model->style_half_size)*sizeof(float));
+  if (!kctx->buf_len_output || prev_size < new_size) {
+    if (kctx->buf_output) {
+      ggml_backend_buffer_free(kctx->buf_len_output);
+      kctx->buf_len_output = nullptr;
+      kctx->lens = nullptr;
+    }
 
-    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
-    // overlap with device computation.
-    ggml_backend_sched_reset(kctx->sched);
-    batch.resp->n_outputs = batch.n_tokens;
+    kctx->buf_len_output =
+        ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
+  }
+
+  batch.resp->hidden_states =
+      (float *)ggml_backend_buffer_get_base(kctx->buf_output);
+  ggml_backend_buffer_clear(kctx->buf_output, 0);
+  batch.resp->lengths =
+      (float *)ggml_backend_buffer_get_base(kctx->buf_len_output);
+  ggml_backend_buffer_clear(kctx->buf_len_output, 0);
+
+  struct ggml_cgraph *gf = NULL;
+  gf = build_kokoro_duration_graph(batch);
+
+  // the output is always the last tensor in the graph
+  struct ggml_tensor *lens = ggml_graph_node(gf, -1);
+  // the reused duration hidden states are computed before a node chunk which
+  // has a size that is sequence length dependent
+  struct ggml_tensor *hidden_states =
+      ggml_graph_node(gf, -22 - 52 * batch.n_tokens);
+  ggml_backend_sched_alloc_graph(kctx->sched, gf);
+
+  set_inputs(batch);
+
+  ggml_backend_sched_graph_compute_async(kctx->sched, gf);
+
+  kctx->get_ggml_node_data(lens, batch.resp->lengths,
+                           batch.n_tokens * sizeof(float),
+                           kctx->buf_len_output);
+  kctx->get_ggml_node_data(
+      hidden_states, batch.resp->hidden_states,
+      batch.n_tokens * (model->duration_hidden_size + model->style_half_size) *
+          sizeof(float));
+
+  // Reset state for the next token before backend sync, to allow the CPU
+  // activities in the reset to overlap with device computation.
+  ggml_backend_sched_reset(kctx->sched);
+  batch.resp->n_outputs = batch.n_tokens;
 }
 
 kokoro_ubatch kokoro_runner::build_worst_case_batch() {
-	kokoro_ubatch batch;
-	batch.n_tokens = model->max_context_length;
-	batch.resp = new kokoro_duration_response;
-	batch.resp->n_outputs = model->max_context_length;
-	kctx->total_duration = model->max_context_length * model->max_duration_per_token;
-	kctx->sequence_length = model->max_context_length;
-	std::vector<float> lengths;
-	lengths.reserve(model->max_context_length);
-	for (int i = 0; i < model->max_context_length; i++) {
-		lengths.push_back(50.0f);
-	}
-	batch.resp->lengths = lengths.data();
-	return batch;
+  kokoro_ubatch batch;
+  batch.n_tokens = model->max_context_length;
+  batch.resp = new kokoro_duration_response;
+  batch.resp->n_outputs = model->max_context_length;
+  kctx->total_duration =
+      model->max_context_length * model->max_duration_per_token;
+  kctx->sequence_length = model->max_context_length;
+  std::vector<float> lengths;
+  lengths.reserve(model->max_context_length);
+  for (int i = 0; i < model->max_context_length; i++) {
+    lengths.push_back(50.0f);
+  }
+  batch.resp->lengths = lengths.data();
+  return batch;
 }
 
-struct ggml_cgraph * kokoro_runner::build_kokoro_graph(kokoro_ubatch & batch) {
-    init_build();
-    // This '570000' number is coming from the number of nodes necessary for the longest possible sequence computed by the graph.
-    // While it may be possible to precompute this by determining the longest possible duration against he maximum context length of the model,
-    // it is not easily performed given that nodes do not necessarily line up predictably with the number of tensors in the model or its submodels.
-    // In order to side step this problem I computed the graph and determined the size in advance and use that constant value here.
-    struct ggml_cgraph * gf = ggml_new_graph_custom(ctx, 570000, false);
+struct ggml_cgraph *kokoro_runner::build_kokoro_graph(kokoro_ubatch &batch) {
+  init_build();
+  // This '570000' number is coming from the number of nodes necessary for the
+  // longest possible sequence computed by the graph. While it may be possible
+  // to precompute this by determining the longest possible duration against he
+  // maximum context length of the model, it is not easily performed given that
+  // nodes do not necessarily line up predictably with the number of tensors in
+  // the model or its submodels. In order to side step this problem I computed
+  // the graph and determined the size in advance and use that constant value
+  // here.
+  struct ggml_cgraph *gf = ggml_new_graph_custom(ctx, 570000, false);
 
-    struct ggml_tensor * voice = model->voices[kctx->voice];
-    struct ggml_tensor * style_half = ggml_view_1d(ctx, voice, voice->ne[0]/2, voice->ne[0] / 2 * voice->nb[0] + (batch.n_tokens - 3) * voice->nb[1]);
-    struct ggml_tensor * cur;
+  struct ggml_tensor *voice = model->voices[kctx->voice];
+  struct ggml_tensor *style_half = ggml_view_1d(
+      ctx, voice, voice->ne[0] / 2,
+      voice->ne[0] / 2 * voice->nb[0] + (batch.n_tokens - 3) * voice->nb[1]);
+  struct ggml_tensor *cur;
 
-    kctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
-    ggml_set_input(kctx->inp_tokens);
+  kctx->inp_tokens = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, batch.n_tokens);
+  ggml_set_input(kctx->inp_tokens);
 
-    kctx->duration_mask = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, kctx->total_duration, kctx->sequence_length);
-    ggml_set_input(kctx->duration_mask);
+  kctx->duration_mask = ggml_new_tensor_2d(
+      ctx, GGML_TYPE_F32, kctx->total_duration, kctx->sequence_length);
+  ggml_set_input(kctx->duration_mask);
 
-    kctx->duration_pred = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, model->duration_hidden_size + model->style_half_size, kctx->sequence_length);
-    ggml_set_input(kctx->duration_pred);
+  kctx->duration_pred = ggml_new_tensor_2d(
+      ctx, GGML_TYPE_F32, model->duration_hidden_size + model->style_half_size,
+      kctx->sequence_length);
+  ggml_set_input(kctx->duration_pred);
 
-    // seeing as we are setting the inputs for these, we shouldn't need to perform tranpositions here
-    cur = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_mask)), ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_pred)));
-    cur = ggml_cont(ctx, ggml_transpose(ctx, cur));
+  // seeing as we are setting the inputs for these, we shouldn't need to perform
+  // tranpositions here
+  cur = ggml_mul_mat(ctx,
+                     ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_mask)),
+                     ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_pred)));
+  cur = ggml_cont(ctx, ggml_transpose(ctx, cur));
 
-    cur = build_lstm(ctx, cur, model->prosody_pred->shared_lstm, cur->ne[1]);
+  cur = build_lstm(ctx, cur, model->prosody_pred->shared_lstm, cur->ne[1]);
 
-    ggml_build_forward_expand(gf, cur);
+  ggml_build_forward_expand(gf, cur);
 
-    struct ggml_tensor * f0_curve = cur;
-    for (auto block : model->prosody_pred->f0_blocks) {
-    	f0_curve = build_ada_residual_conv(ctx, f0_curve, block, style_half, model->sqrt_tensor);
+  struct ggml_tensor *f0_curve = cur;
+  for (auto block : model->prosody_pred->f0_blocks) {
+    f0_curve = build_ada_residual_conv(ctx, f0_curve, block, style_half,
+                                       model->sqrt_tensor);
+  }
+  f0_curve = ggml_add(
+      ctx,
+      ggml_conv_1d(ctx, model->prosody_pred->f0_proj_kernel,
+                   ggml_cont(ctx, ggml_transpose(ctx, f0_curve)), 1, 0, 1),
+      model->prosody_pred->f0_proj_bias);
+  ggml_set_name(f0_curve, "f0_out");
+
+  struct ggml_tensor *n = cur;
+  for (auto block : model->prosody_pred->n_blocks) {
+    n = build_ada_residual_conv(ctx, n, block, style_half, model->sqrt_tensor);
+  }
+  n = ggml_add(ctx,
+               ggml_conv_1d(ctx, model->prosody_pred->n_proj_kernel,
+                            ggml_cont(ctx, ggml_transpose(ctx, n)), 1, 0, 1),
+               model->prosody_pred->n_proj_bias);
+  ggml_set_name(n, "n_out");
+  ggml_build_forward_expand(gf, n);
+
+  // kokoro text encoding;
+  struct ggml_tensor *asr;
+  // struct ggml_tensor * embd;
+  {
+    cur = ggml_get_rows(ctx, model->text_encoder->embd, kctx->inp_tokens);
+
+    for (auto l : model->text_encoder->conv_layers) {
+      cur = ggml_cont(
+          ctx,
+          ggml_transpose(
+              ctx,
+              ggml_add(ctx,
+                       ggml_conv_1d(ctx, l->conv_weight,
+                                    ggml_cont(ctx, ggml_transpose(ctx, cur)), 1,
+                                    2, 1),
+                       l->conv_bias)));
+      cur = ggml_norm(ctx, cur, 0.00001);
+      cur = ggml_add(ctx, ggml_mul(ctx, cur, l->norm_gamma), l->norm_beta);
+      cur = ggml_leaky_relu(ctx, cur, 0.2f, false);
     }
-    f0_curve = ggml_add(ctx, ggml_conv_1d(ctx, model->prosody_pred->f0_proj_kernel, ggml_cont(ctx, ggml_transpose(ctx, f0_curve)), 1, 0, 1), model->prosody_pred->f0_proj_bias);
-    ggml_set_name(f0_curve, "f0_out");
 
-    struct ggml_tensor * n = cur;
-    for (auto block : model->prosody_pred->n_blocks) {
-		n = build_ada_residual_conv(ctx, n, block, style_half, model->sqrt_tensor);
+    cur = build_lstm(ctx, cur, model->text_encoder->out_lstm,
+                     kctx->sequence_length);
+    asr =
+        ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)),
+                     ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_mask)));
+  }
+
+  // decoding and generation prep
+  struct ggml_tensor *asr_res;
+  struct ggml_tensor *f0;
+  struct ggml_tensor *n_base;
+  struct ggml_tensor *style_half2 = ggml_view_1d(
+      ctx, voice, voice->ne[0] / 2, (batch.n_tokens - 3) * voice->nb[1]);
+
+  {
+    f0 = ggml_cont(
+        ctx,
+        ggml_transpose(ctx, ggml_add(ctx,
+                                     ggml_conv_1d(ctx, model->decoder->f0_conv,
+                                                  f0_curve, 2, 1, 1),
+                                     model->decoder->f0_conv_bias)));
+    n_base = ggml_cont(
+        ctx,
+        ggml_transpose(
+            ctx,
+            ggml_add(ctx, ggml_conv_1d(ctx, model->decoder->n_conv, n, 2, 1, 1),
+                     model->decoder->n_conv_bias)));
+    cur = ggml_concat(ctx, ggml_concat(ctx, asr, f0, 0), n_base, 0);
+
+    cur = build_ada_residual_conv(ctx, cur, model->decoder->encoder_block,
+                                  style_half2, model->sqrt_tensor);
+    asr_res = ggml_cont(
+        ctx,
+        ggml_transpose(
+            ctx, ggml_add(ctx,
+                          ggml_conv_1d(ctx, model->decoder->asr_conv,
+                                       ggml_cont(ctx, ggml_transpose(ctx, asr)),
+                                       1, 0, 1),
+                          model->decoder->asr_conv_bias)));
+
+    for (auto l : model->decoder->decoder_blocks) {
+      cur = ggml_concat(
+          ctx, ggml_concat(ctx, ggml_concat(ctx, cur, asr_res, 0), f0, 0),
+          n_base, 0);
+      cur =
+          build_ada_residual_conv(ctx, cur, l, style_half2, model->sqrt_tensor);
     }
-	n = ggml_add(ctx, ggml_conv_1d(ctx, model->prosody_pred->n_proj_kernel, ggml_cont(ctx, ggml_transpose(ctx, n)), 1, 0, 1), model->prosody_pred->n_proj_bias);
-	ggml_set_name(n, "n_out");
-	ggml_build_forward_expand(gf, n);
-    
-	// kokoro text encoding;
-	struct ggml_tensor * asr;
-	//struct ggml_tensor * embd;
-	{
-		cur = ggml_get_rows(ctx, model->text_encoder->embd, kctx->inp_tokens);
+  }
 
-		for (auto l : model->text_encoder->conv_layers) {
-			cur = ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_conv_1d(ctx, l->conv_weight, ggml_cont(ctx, ggml_transpose(ctx, cur)), 1, 2, 1), l->conv_bias)));
-			cur = ggml_norm(ctx, cur, 0.00001);
-			cur = ggml_add(ctx, ggml_mul(ctx, cur, l->norm_gamma), l->norm_beta);
-			cur = ggml_leaky_relu(ctx, cur, 0.2f, false);
-		}
+  kctx->window_sq_sum = ggml_new_tensor_1d(
+      ctx, GGML_TYPE_F32, kctx->total_duration * model->up_sampling_factor);
+  ggml_set_input(kctx->window_sq_sum);
 
-		cur = build_lstm(ctx, cur, model->text_encoder->out_lstm, kctx->sequence_length);
-		asr = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, cur)), ggml_cont(ctx, ggml_transpose(ctx, kctx->duration_mask)));
-	}
-
-	// decoding and generation prep 
-	struct ggml_tensor * asr_res;
-	struct ggml_tensor * f0;
-	struct ggml_tensor * n_base;
-	struct ggml_tensor * style_half2 = ggml_view_1d(ctx, voice, voice->ne[0]/2, (batch.n_tokens - 3) * voice->nb[1]);
-
-	{
-		f0 = ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_conv_1d(ctx, model->decoder->f0_conv, f0_curve, 2, 1, 1), model->decoder->f0_conv_bias)));
-		n_base = ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_conv_1d(ctx, model->decoder->n_conv, n, 2, 1, 1), model->decoder->n_conv_bias)));
-		cur = ggml_concat(ctx, ggml_concat(ctx, asr, f0, 0), n_base, 0);
-
-		cur = build_ada_residual_conv(ctx, cur, model->decoder->encoder_block, style_half2, model->sqrt_tensor);
-		asr_res = ggml_cont(ctx, ggml_transpose(ctx, ggml_add(ctx, ggml_conv_1d(ctx, model->decoder->asr_conv, ggml_cont(ctx, ggml_transpose(ctx, asr)), 1, 0, 1), model->decoder->asr_conv_bias)));
-
-		for (auto l : model->decoder->decoder_blocks) {
-			cur = ggml_concat(ctx, ggml_concat(ctx, ggml_concat(ctx, cur, asr_res, 0), f0, 0), n_base, 0);
-			cur = build_ada_residual_conv(ctx, cur, l, style_half2, model->sqrt_tensor);
-		}
-	}
-
-	kctx->window_sq_sum = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, kctx->total_duration*model->up_sampling_factor);
-	ggml_set_input(kctx->window_sq_sum);
-
-	// run generation
-	cur = build_generator(ctx, model, kctx, cur, style_half2, f0_curve, model->decoder->generator, (int)kctx->sequence_length, kctx->window_sq_sum, gf);
-    ggml_build_forward_expand(gf, cur);
-    free_build();
-    return gf;
+  // run generation
+  cur = build_generator(ctx, model, kctx, cur, style_half2, f0_curve,
+                        model->decoder->generator, (int)kctx->sequence_length,
+                        kctx->window_sq_sum, gf);
+  ggml_build_forward_expand(gf, cur);
+  free_build();
+  return gf;
 }
 
 void kokoro_runner::prepare_post_load() {
-	model->post_load_assign();
-	drunner->prepare_post_load();
-    auto batch = build_worst_case_batch();
-    auto gf = build_kokoro_graph(batch);
-    kctx->prep_schedule(gf);
-    free(batch.resp);
+  model->post_load_assign();
+  drunner->prepare_post_load();
+  auto batch = build_worst_case_batch();
+  auto gf = build_kokoro_graph(batch);
+  kctx->prep_schedule(gf);
+  free(batch.resp);
 }
 
-void kokoro_runner::set_inputs(kokoro_ubatch & batch, uint32_t total_size) {
-	random_gen(total_size * model->up_sampling_factor * (model->harmonic_num + 1), ((float*)kctx->uv_noise_data->data) + 4);
-    ((float*) kctx->uv_noise_data->data)[0] = model->voice_threshold;
-    ((float*) kctx->uv_noise_data->data)[1] = model->noise_std;
-    ((float*) kctx->uv_noise_data->data)[2] = model->sin_amp;
-    ((float*) kctx->uv_noise_data->data)[3] = model->sin_amp / 3.0f;
-	compute_window_squared_sum(model->true_n_fft, model->stft_hop, total_size*model->up_sampling_factor/model->stft_hop, (float*) kctx->window_sq_sum->data, (float*) model->decoder->generator->window->data);
-	kctx->sequence_length = batch.n_tokens;
-	kctx->total_duration = total_size;
-	ggml_backend_tensor_set(kctx->inp_tokens, batch.input_tokens, 0, batch.n_tokens*ggml_element_size(kctx->inp_tokens));
-	ggml_backend_tensor_set(kctx->duration_pred, batch.resp->hidden_states, 0, batch.n_tokens*(model->duration_hidden_size + model->style_half_size)*ggml_element_size(kctx->duration_pred));
-	float * d = nullptr;
-	float running = 0;
-    d = (float *) kctx->duration_mask->data;
-	for (uint32_t i = 0; i < batch.n_tokens; i++) {
-		float next_running = running + batch.resp->lengths[i];
-		for (uint32_t ii = 0; ii < total_size; ii++) {
-			d[i*total_size+ii] = ii >= running && ii < next_running ? 1.0f : 0.0f;
-		}
-		running = next_running;
+void kokoro_runner::set_inputs(kokoro_ubatch &batch, uint32_t total_size) {
+  random_gen(total_size * model->up_sampling_factor * (model->harmonic_num + 1),
+             ((float *)kctx->uv_noise_data->data) + 4);
+  ((float *)kctx->uv_noise_data->data)[0] = model->voice_threshold;
+  ((float *)kctx->uv_noise_data->data)[1] = model->noise_std;
+  ((float *)kctx->uv_noise_data->data)[2] = model->sin_amp;
+  ((float *)kctx->uv_noise_data->data)[3] = model->sin_amp / 3.0f;
+  compute_window_squared_sum(model->true_n_fft, model->stft_hop,
+                             total_size * model->up_sampling_factor /
+                                 model->stft_hop,
+                             (float *)kctx->window_sq_sum->data,
+                             (float *)model->decoder->generator->window->data);
+  kctx->sequence_length = batch.n_tokens;
+  kctx->total_duration = total_size;
+  ggml_backend_tensor_set(kctx->inp_tokens, batch.input_tokens, 0,
+                          batch.n_tokens * ggml_element_size(kctx->inp_tokens));
+  ggml_backend_tensor_set(
+      kctx->duration_pred, batch.resp->hidden_states, 0,
+      batch.n_tokens * (model->duration_hidden_size + model->style_half_size) *
+          ggml_element_size(kctx->duration_pred));
+  float *d = nullptr;
+  float running = 0;
+  d = (float *)kctx->duration_mask->data;
+  for (uint32_t i = 0; i < batch.n_tokens; i++) {
+    float next_running = running + batch.resp->lengths[i];
+    for (uint32_t ii = 0; ii < total_size; ii++) {
+      d[i * total_size + ii] = ii >= running && ii < next_running ? 1.0f : 0.0f;
     }
+    running = next_running;
+  }
 }
 
-void kokoro_runner::run(kokoro_ubatch & batch, tts_response * outputs) {
-	batch.resp = new kokoro_duration_response;
-	drunner->run(batch);
+void kokoro_runner::run(kokoro_ubatch &batch, tts_response *outputs) {
+  batch.resp = new kokoro_duration_response;
+  drunner->run(batch);
 
-	ggml_backend_sched_reset(kctx->sched);
+  ggml_backend_sched_reset(kctx->sched);
 
-    const size_t prev_size = kctx->buf_output ? ggml_backend_buffer_get_size(kctx->buf_output) : 0;
-    uint32_t total_length = 0;
-    for (int i = 0; i < batch.resp->n_outputs; i++) {
-    	total_length += (uint32_t) batch.resp->lengths[i];
+  const size_t prev_size =
+      kctx->buf_output ? ggml_backend_buffer_get_size(kctx->buf_output) : 0;
+  uint32_t total_length = 0;
+  for (int i = 0; i < batch.resp->n_outputs; i++) {
+    total_length += (uint32_t)batch.resp->lengths[i];
+  }
+  const size_t new_size =
+      total_length * model->up_sampling_factor * sizeof(float);
+
+  if (!kctx->buf_output || prev_size < new_size) {
+    if (kctx->buf_output) {
+      ggml_backend_buffer_free(kctx->buf_output);
+      kctx->buf_output = nullptr;
+      kctx->logits = nullptr;
     }
-    const size_t new_size = total_length * model->up_sampling_factor * sizeof(float);
+    kctx->buf_output =
+        ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
+  }
 
-    if (!kctx->buf_output || prev_size < new_size) {
-        if (kctx->buf_output) {
-            ggml_backend_buffer_free(kctx->buf_output);
-            kctx->buf_output = nullptr;
-            kctx->logits = nullptr;
-        }
-        kctx->buf_output = ggml_backend_buft_alloc_buffer(kctx->backend_cpu_buffer, new_size);
-    }
+  outputs->data = (float *)ggml_backend_buffer_get_base(kctx->buf_output);
+  ggml_backend_buffer_clear(kctx->buf_output, 0);
 
-    outputs->data = (float *) ggml_backend_buffer_get_base(kctx->buf_output);
-    ggml_backend_buffer_clear(kctx->buf_output, 0);
+  kctx->sequence_length = batch.n_tokens;
+  kctx->total_duration = total_length;
 
-    kctx->sequence_length = batch.n_tokens;
-	kctx->total_duration = total_length;
+  struct ggml_cgraph *gf = NULL;
+  gf = build_kokoro_graph(batch);
 
-    struct ggml_cgraph * gf = NULL;
-    gf = build_kokoro_graph(batch);
-    
-    // the output is always the last tensor in the graph
-    struct ggml_tensor * output = gf->nodes[gf->n_nodes - 1];
+  // the output is always the last tensor in the graph
+  struct ggml_tensor *output = ggml_graph_node(gf, -1);
 
-    ggml_backend_sched_alloc_graph(kctx->sched, gf);
-    
-    set_inputs(batch, total_length);
+  ggml_backend_sched_alloc_graph(kctx->sched, gf);
 
-    ggml_backend_sched_graph_compute_async(kctx->sched, gf);
+  set_inputs(batch, total_length);
 
-    kctx->get_ggml_node_data(output, outputs->data, new_size);
+  ggml_backend_sched_graph_compute_async(kctx->sched, gf);
 
-    // Reset state for the next token before backend sync, to allow the CPU activities in the reset to
-    // overlap with device computation.
-    ggml_backend_sched_reset(kctx->sched);
-    outputs->n_outputs = total_length*model->up_sampling_factor;
-    free(batch.resp);
-    return;
+  kctx->get_ggml_node_data(output, outputs->data, new_size);
+
+  // Reset state for the next token before backend sync, to allow the CPU
+  // activities in the reset to overlap with device computation.
+  ggml_backend_sched_reset(kctx->sched);
+  outputs->n_outputs = total_length * model->up_sampling_factor;
+  free(batch.resp);
+  return;
 }
 
-void kokoro_runner::assign_weight(std::string name, ggml_tensor * tensor) {
-	model->assign_weight(name, tensor);
+void kokoro_runner::assign_weight(std::string name, ggml_tensor *tensor) {
+  model->assign_weight(name, tensor);
 }
 
 /*
- * #tokenize_chunks is used to split up a larger than max context size (512) token prompt into discrete
- * blocks for generation. This solution, in accordance with Kokoro's pyTorch implementation, splits
- * the prompt by sentence when possible (this can result in slower inference but generally produces cleaner 
- * speech). If a disinct sentence is too long, then it splits at the nearest space.
+ * #tokenize_chunks is used to split up a larger than max context size (512)
+ * token prompt into discrete blocks for generation. This solution, in
+ * accordance with Kokoro's pyTorch implementation, splits the prompt by
+ * sentence when possible (this can result in slower inference but generally
+ * produces cleaner speech). If a disinct sentence is too long, then it splits
+ * at the nearest space.
  */
-std::vector<std::vector<uint32_t>> kokoro_runner::tokenize_chunks(std::vector<std::string> clauses) {
-	std::vector<std::vector<uint32_t>> chunks;
-	for (auto clause : clauses) {
-		clause = strip(clause);
-		if (clause.empty()) {
-			continue;
-		} 
-		std::vector<uint32_t> tokens;
-		tokens.push_back(model->bos_token_id);
-		tokenizer->tokenize(clause, tokens);
-		// if there are more clause tokens than the max context length then try to split by space tokens.
-		// To be protective, split mid-word when there are no spaces (this should never happen).
-		if (tokens.size() > model->max_context_length - 2) {
-			// we skip the first token here becuase it is the bos token.
-			int last_space_token = 1;
-			int last_split = 1;
-			for (int i = 1; i < tokens.size(); i++) {
-				if (tokens[i] == model->space_token_id) {
-					last_space_token = i;
-				}
-				if ((i - last_split) + chunks.back().size() >= model->max_context_length - 1) {
-					if (last_space_token > last_split) {
-						std::vector<uint32_t> portion = { model->bos_token_id };
-						portion.insert(portion.end(), tokens.begin() + last_split, tokens.begin() + last_space_token);
-						portion.push_back(model->eos_token_id);
-						chunks.push_back(portion);
-						last_split = last_space_token;
-					} else {
-						std::vector<uint32_t> portion = { model->bos_token_id };
-						portion.insert(portion.end(), tokens.begin() + last_split, tokens.begin() + i + 1);
-						portion.push_back(model->eos_token_id);
-						chunks.push_back(portion);
-						last_split = i + 1;
-					}
-				}
-			}
-			if (last_split + 1 < tokens.size()) {
-				std::vector<uint32_t> portion = { model->bos_token_id };
-				portion.insert(portion.end(), tokens.begin() + last_split, tokens.end());
-				portion.push_back(model->eos_token_id);
-				chunks.push_back(portion);
-			}
-		} else {
-			tokens.push_back(model->eos_token_id);
-			chunks.push_back(tokens);
-		}
-	}
-	return chunks;
-}
-
-int kokoro_runner::generate(std::string prompt, struct tts_response * response, std::string voice, std::string voice_code) {
-	if (model->voices.find(voice) == model->voices.end()) {
-		TTS_ABORT("Failed to find Kokoro voice '%s' aborting.\n", voice.c_str());
-    } else {
-    	// if the language changed then we should change the phonemization voice
-    	if (phmzr->mode == ESPEAK && kctx->voice[0] != voice[0]) {
-    		if (voice_code.empty()) {
-    			voice_code = get_espeak_id_from_kokoro_voice(voice);
-    		}
-    		update_voice(voice_code);
-    	}
-        kctx->voice = voice;
-        drunner->kctx->voice = voice;
+std::vector<std::vector<uint32_t>>
+kokoro_runner::tokenize_chunks(std::vector<std::string> clauses) {
+  std::vector<std::vector<uint32_t>> chunks;
+  for (auto clause : clauses) {
+    clause = strip(clause);
+    if (clause.empty()) {
+      continue;
     }
-    // replace all non-sentence terminating characters with '--' which espeak will treat as a pause.
-    // We preserve the other punctuation for cleaner chunking pre-tokenization
-    prompt = replace_any(prompt, ",;:", "--");
-    prompt = replace_any(prompt, "\n", " ");
-  	std::string phonemized_prompt = phmzr->text_to_phonemes(prompt);
-
-  	// Kokoro users a utf-8 single character tokenizer so if the size of the prompt is smaller than the max context length without the 
-  	// beginning of sentence and end of sentence tokens then we can compute it all at once.
-  	if (phonemized_prompt.size() < model->max_context_length - 2) { 
-  		// we preserved punctuation and Kokoro interprets these tokens as end of sentence tokens, so we have to remove them for all-at-once compute.
-  		phonemized_prompt = strip(replace_any(phonemized_prompt, ".!?", ""));
-  		if (phonemized_prompt.empty()) {
-  			return 0;
-  		}
-		std::vector<uint32_t> tokens;
-		tokens.push_back(model->bos_token_id);
-		tokenizer->tokenize(phonemized_prompt, tokens);
-		tokens.push_back(model->eos_token_id);
-		kokoro_ubatch batch;
-		batch.n_tokens = tokens.size();
-		batch.input_tokens = tokens.data();
-		run(batch, response);
-  	} else {
-  		// TODO: determine the performance to memory trade off in using a batched compute approach verse this chunking approach.
-  		// This approach is likely to be slower than a batched approach, but given the already huge memory overhead of Kokoro's graph it 
-  		// might be preferable to use this chunking approach.
-  		std::vector<std::string> clauses = split(phonemized_prompt, ".!?");
-  		for (auto tokens : tokenize_chunks(clauses)) {
-			kokoro_ubatch batch;
-			batch.n_tokens = tokens.size();
-			batch.input_tokens = tokens.data();
-			struct tts_response * partial = new tts_response;
-			run(batch, partial);
-			append_to_response(response, partial);
-		}
-  	}
-  	return 0;
+    std::vector<uint32_t> tokens;
+    tokens.push_back(model->bos_token_id);
+    tokenizer->tokenize(clause, tokens);
+    // if there are more clause tokens than the max context length then try to
+    // split by space tokens. To be protective, split mid-word when there are no
+    // spaces (this should never happen).
+    if (tokens.size() > model->max_context_length - 2) {
+      // we skip the first token here becuase it is the bos token.
+      int last_space_token = 1;
+      int last_split = 1;
+      for (int i = 1; i < tokens.size(); i++) {
+        if (tokens[i] == model->space_token_id) {
+          last_space_token = i;
+        }
+        if ((i - last_split) + chunks.back().size() >=
+            model->max_context_length - 1) {
+          if (last_space_token > last_split) {
+            std::vector<uint32_t> portion = {model->bos_token_id};
+            portion.insert(portion.end(), tokens.begin() + last_split,
+                           tokens.begin() + last_space_token);
+            portion.push_back(model->eos_token_id);
+            chunks.push_back(portion);
+            last_split = last_space_token;
+          } else {
+            std::vector<uint32_t> portion = {model->bos_token_id};
+            portion.insert(portion.end(), tokens.begin() + last_split,
+                           tokens.begin() + i + 1);
+            portion.push_back(model->eos_token_id);
+            chunks.push_back(portion);
+            last_split = i + 1;
+          }
+        }
+      }
+      if (last_split + 1 < tokens.size()) {
+        std::vector<uint32_t> portion = {model->bos_token_id};
+        portion.insert(portion.end(), tokens.begin() + last_split,
+                       tokens.end());
+        portion.push_back(model->eos_token_id);
+        chunks.push_back(portion);
+      }
+    } else {
+      tokens.push_back(model->eos_token_id);
+      chunks.push_back(tokens);
+    }
+  }
+  return chunks;
 }
 
+int kokoro_runner::generate(std::string prompt, struct tts_response *response,
+                            std::string voice, std::string voice_code) {
+  if (model->voices.find(voice) == model->voices.end()) {
+    TTS_ABORT("Failed to find Kokoro voice '%s' aborting.\n", voice.c_str());
+  } else {
+    // if the language changed then we should change the phonemization voice
+    if (phmzr->mode == ESPEAK && kctx->voice[0] != voice[0]) {
+      if (voice_code.empty()) {
+        voice_code = get_espeak_id_from_kokoro_voice(voice);
+      }
+      update_voice(voice_code);
+    }
+    kctx->voice = voice;
+    drunner->kctx->voice = voice;
+  }
+  // replace all non-sentence terminating characters with '--' which espeak will
+  // treat as a pause. We preserve the other punctuation for cleaner chunking
+  // pre-tokenization
+  prompt = replace_any(prompt, ",;:", "--");
+  prompt = replace_any(prompt, "\n", " ");
+  std::string phonemized_prompt = phmzr->text_to_phonemes(prompt);
+
+  // Kokoro users a utf-8 single character tokenizer so if the size of the
+  // prompt is smaller than the max context length without the beginning of
+  // sentence and end of sentence tokens then we can compute it all at once.
+  if (phonemized_prompt.size() < model->max_context_length - 2) {
+    // we preserved punctuation and Kokoro interprets these tokens as end of
+    // sentence tokens, so we have to remove them for all-at-once compute.
+    phonemized_prompt = strip(replace_any(phonemized_prompt, ".!?", ""));
+    if (phonemized_prompt.empty()) {
+      return 0;
+    }
+    std::vector<uint32_t> tokens;
+    tokens.push_back(model->bos_token_id);
+    tokenizer->tokenize(phonemized_prompt, tokens);
+    tokens.push_back(model->eos_token_id);
+    kokoro_ubatch batch;
+    batch.n_tokens = tokens.size();
+    batch.input_tokens = tokens.data();
+    run(batch, response);
+  } else {
+    // TODO: determine the performance to memory trade off in using a batched
+    // compute approach verse this chunking approach. This approach is likely to
+    // be slower than a batched approach, but given the already huge memory
+    // overhead of Kokoro's graph it might be preferable to use this chunking
+    // approach.
+    std::vector<std::string> clauses = split(phonemized_prompt, ".!?");
+    for (auto tokens : tokenize_chunks(clauses)) {
+      kokoro_ubatch batch;
+      batch.n_tokens = tokens.size();
+      batch.input_tokens = tokens.data();
+      struct tts_response *partial = new tts_response;
+      run(batch, partial);
+      append_to_response(response, partial);
+    }
+  }
+  return 0;
+}
 
 std::string get_espeak_id_from_kokoro_voice(std::string voice) {
-	return !voice.empty() && KOKORO_LANG_TO_ESPEAK_ID.find(voice[0]) != KOKORO_LANG_TO_ESPEAK_ID.end() ? KOKORO_LANG_TO_ESPEAK_ID[voice[0]] : "gmw/en-US";
+  return !voice.empty() && KOKORO_LANG_TO_ESPEAK_ID.find(voice[0]) !=
+                               KOKORO_LANG_TO_ESPEAK_ID.end()
+             ? KOKORO_LANG_TO_ESPEAK_ID[voice[0]]
+             : "gmw/en-US";
 }
 
-struct kokoro_duration_context * build_new_duration_kokoro_context(struct kokoro_model * model, int n_threads, bool use_cpu) {
-    kokoro_duration_context * kctx = new kokoro_duration_context(model, n_threads);
-    if (!use_cpu) {
+struct kokoro_duration_context *
+build_new_duration_kokoro_context(struct kokoro_model *model, int n_threads,
+                                  bool use_cpu) {
+  kokoro_duration_context *kctx = new kokoro_duration_context(model, n_threads);
+  if (!use_cpu) {
 #ifdef GGML_USE_METAL
-        kctx->backend = ggml_backend_metal_init();
+    kctx->backend = ggml_backend_metal_init();
 #endif
-    }
-    kctx->backend_cpu = ggml_backend_cpu_init();
-    kctx->set_threads();
-    kctx->build_schedule();
-    kctx->buf_compute_meta.resize(ggml_tensor_overhead()*model->max_duration_nodes()*5 + ggml_graph_overhead_custom(model->max_duration_nodes()*5, false));
-    return kctx;
+  }
+  kctx->backend_cpu = ggml_backend_cpu_init();
+  kctx->set_threads();
+  kctx->build_schedule();
+  kctx->buf_compute_meta.resize(
+      ggml_tensor_overhead() * model->max_duration_nodes() * 5 +
+      ggml_graph_overhead_custom(model->max_duration_nodes() * 5, false));
+  return kctx;
 }
 
-
-struct kokoro_context * build_new_kokoro_context(struct kokoro_model * model, int n_threads, bool use_cpu) {
-    kokoro_context * kctx = new kokoro_context(model, n_threads);
-    if (!use_cpu) {
+struct kokoro_context *build_new_kokoro_context(struct kokoro_model *model,
+                                                int n_threads, bool use_cpu) {
+  kokoro_context *kctx = new kokoro_context(model, n_threads);
+  if (!use_cpu) {
 #ifdef GGML_USE_METAL
-        kctx->backend = ggml_backend_metal_init();
+    kctx->backend = ggml_backend_metal_init();
 #endif
-    }
-    kctx->backend_cpu = ggml_backend_cpu_init();
-    kctx->set_threads();
-    kctx->build_schedule();
-    kctx->buf_compute_meta.resize(ggml_tensor_overhead()*model->max_gen_nodes()*30 + ggml_graph_overhead_custom(model->max_gen_nodes()*30, false));
-    return kctx;
+  }
+  kctx->backend_cpu = ggml_backend_cpu_init();
+  kctx->set_threads();
+  kctx->build_schedule();
+  kctx->buf_compute_meta.resize(
+      ggml_tensor_overhead() * model->max_gen_nodes() * 30 +
+      ggml_graph_overhead_custom(model->max_gen_nodes() * 30, false));
+  return kctx;
 }

--- a/src/kokoro_model.h
+++ b/src/kokoro_model.h
@@ -5,6 +5,7 @@
 #include "tts_model.h"
 #include "tokenizer.h"
 #include "phonemizer.h"
+#include "ggml-tts-ext.h"
 
 // Rather than using ISO 639-2 language codes, Kokoro voice pack specify their corresponding language via their first letter.
 // Below is a map that describes the relationship between those designations and espeak-ng's voice identifiers so that the 

--- a/src/parler_model.cpp
+++ b/src/parler_model.cpp
@@ -114,7 +114,7 @@ void parler_tts_model::prep_cross_key_values(int n_threads, struct tts_response 
     ggml_backend_cpu_set_n_threads(backend_cpu, n_threads);
     std::vector<ggml_backend_buffer_type_t> bufs = {backend_cpu_buffer};
     std::vector<ggml_backend_t> backs = {backend_cpu};
-    ggml_backend_sched_t sched = ggml_backend_sched_new(backs.data(), bufs.data(), 1, max_cross_nodes*n_layers, false);
+    ggml_backend_sched_t sched = ggml_backend_sched_new(backs.data(), bufs.data(), 1, max_cross_nodes*n_layers, false, true);
     
     std::vector<uint8_t> buf_compute_meta;
     buf_compute_meta.resize(max_cross_nodes*n_layers*ggml_tensor_overhead() + ggml_graph_overhead_custom(max_cross_nodes*n_layers, false));
@@ -686,7 +686,7 @@ int parler_tts_runner::decode(parler_ubatch & batch) {
     ggml_cgraph * gf = build_parler_graph(batch);
 
     // the output is always the last tensor in the graph
-    struct ggml_tensor * res = gf->nodes[gf->n_nodes - 1];
+    struct ggml_tensor * res = ggml_graph_node(gf, -1);
     ggml_backend_sched_alloc_graph(pctx->sched, gf);
     
     // use the sequence_length variable here so that audio input tokens are handled correctly.

--- a/src/t5_encoder_model.cpp
+++ b/src/t5_encoder_model.cpp
@@ -343,7 +343,7 @@ void t5_runner::run(uint32_t * input_tokens, uint32_t sequence_length, struct tt
     struct ggml_cgraph * gf = NULL;
     gf = build_t5_graph(batch);
     // the output is always the last tensor in the graph
-    struct ggml_tensor * result = gf->nodes[gf->n_nodes - 1];
+    struct ggml_tensor * result = ggml_graph_node(gf, -1);
     ggml_backend_sched_alloc_graph(t5ctx->sched, gf);
     set_inputs(batch);
 

--- a/src/tts.cpp
+++ b/src/tts.cpp
@@ -179,11 +179,11 @@ bool is_quanitizable(tts_arch arch, std::string name, struct quantization_params
 size_t quantize_tensor(void * new_data, struct ggml_tensor * tensor, const float * imatrix, enum ggml_type qtype, uint32_t n_threads) {
     // much of this is form copied from llama.cpp
     int chunk_size_multiplier = 1;
-    if (qtype == GGML_TYPE_Q4_0_4_4 || qtype == GGML_TYPE_Q4_0_4_8 || qtype == GGML_TYPE_Q4_0_8_8) {
-        if ((qtype == GGML_TYPE_Q4_0_8_8) && (tensor->ne[1] % 8 != 0)) qtype = GGML_TYPE_Q4_0;
-        else if (tensor->ne[1] % 4 != 0) qtype = GGML_TYPE_Q4_0;
-        if (qtype == GGML_TYPE_Q4_0_8_8) chunk_size_multiplier = 8;
-        else if (qtype == GGML_TYPE_Q4_0_4_4 || qtype == GGML_TYPE_Q4_0_4_8) chunk_size_multiplier = 4;
+    // Note: GGML_TYPE_Q4_0_4_4, GGML_TYPE_Q4_0_4_8, GGML_TYPE_Q4_0_8_8 have been removed from llama.cpp
+    // Fallback to standard GGML_TYPE_Q4_0 for compatibility
+    if (qtype == GGML_TYPE_Q4_0) {
+        // Use standard Q4_0 quantization
+        chunk_size_multiplier = 1;
     }
     size_t out_size = 0;
     const int32_t d3_step = tensor->ne[0] * tensor->ne[1];
@@ -363,7 +363,7 @@ void quantize_gguf(const std::string & ifile, const std::string & ofile, struct 
         }
 
         gguf_set_tensor_type(ctx_out.get(), name.c_str(), new_type);
-        gguf_set_tensor_data(ctx_out.get(), name.c_str(), new_data, new_size);
+        gguf_set_tensor_data(ctx_out.get(), name.c_str(), new_data);
         fprintf(stdout, "At tensor: '%s' with new size: %zu bytes\n", name.c_str(), new_size);
         // write tensor data + padding
         fout.write((const char *) new_data, new_size);

--- a/src/tts_model.cpp
+++ b/src/tts_model.cpp
@@ -1,144 +1,181 @@
 #include "tts_model.h"
+#include "ggml-alloc.h"
 #include "ggml-backend.h"
 #include "ggml-cpu.h"
+#include "ggml.h"
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
+// Removed ggml-tts.h - using standard llama.cpp/ggml operations
+#include "gguf.h"
 
-void append_to_response(struct tts_response * response, struct tts_response * to_append) {
-    float * new_data = (float *) malloc((response->n_outputs + to_append->n_outputs) * sizeof(float));
-    if (response->n_outputs > 0) {
-        std::memcpy(new_data, response->data, response->n_outputs*sizeof(float));
-    }
-    if (to_append->n_outputs > 0) {
-        float * next_loc = new_data + response->n_outputs;
-        std::memcpy(next_loc, to_append->data, to_append->n_outputs*sizeof(float));
-    }
-    response->data = new_data;
-    response->n_outputs += to_append->n_outputs;
+void append_to_response(struct tts_response *response,
+                        struct tts_response *to_append) {
+  float *new_data = (float *)malloc(
+      (response->n_outputs + to_append->n_outputs) * sizeof(float));
+  if (response->n_outputs > 0) {
+    std::memcpy(new_data, response->data, response->n_outputs * sizeof(float));
+  }
+  if (to_append->n_outputs > 0) {
+    float *next_loc = new_data + response->n_outputs;
+    std::memcpy(next_loc, to_append->data,
+                to_append->n_outputs * sizeof(float));
+  }
+  response->data = new_data;
+  response->n_outputs += to_append->n_outputs;
 }
 
-/* 
- * Pulls output_size to prepped buffer 'output' from 'output_node' tensor. If no buffer is passed will default to the existing output buffer present 
- * on runner_context. 
+/*
+ * Pulls output_size to prepped buffer 'output' from 'output_node' tensor. If no
+ * buffer is passed will default to the existing output buffer present on
+ * runner_context.
  */
-void runner_context::get_ggml_node_data(struct ggml_tensor * output_node, float * output, size_t output_size, ggml_backend_buffer_t buffer) {
-    if (buffer == nullptr) {
-        buffer = buf_output;
-    }
-    if (ggml_backend_buffer_get_size(buffer) < output_size) {
-        TTS_ABORT("Output buffer overflow of %d / %d for output node '%s'\n", output_size, ggml_backend_buffer_get_size(buffer), ggml_get_name(output_node));
-    } else if (ggml_nbytes(output_node) < output_size) {
-        TTS_ABORT("Output node, '%s', with %d bytes is too small for #ggml_backend_tensor_get_async with size of %d.\n", ggml_get_name(output_node), ggml_nbytes(output_node), output_size);
-    }
-    ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched, output_node);
-    ggml_backend_tensor_get_async(backend_res, output_node, output, 0, output_size);
+void runner_context::get_ggml_node_data(struct ggml_tensor *output_node,
+                                        float *output, size_t output_size,
+                                        ggml_backend_buffer_t buffer) {
+  if (buffer == nullptr) {
+    buffer = buf_output;
+  }
+  if (ggml_backend_buffer_get_size(buffer) < output_size) {
+    TTS_ABORT("Output buffer overflow of %d / %d for output node '%s'\n",
+              output_size, ggml_backend_buffer_get_size(buffer),
+              ggml_get_name(output_node));
+  } else if (ggml_nbytes(output_node) < output_size) {
+    TTS_ABORT("Output node, '%s', with %d bytes is too small for "
+              "#ggml_backend_tensor_get_async with size of %d.\n",
+              ggml_get_name(output_node), ggml_nbytes(output_node),
+              output_size);
+  }
+  ggml_backend_t backend_res =
+      ggml_backend_sched_get_tensor_backend(sched, output_node);
+  ggml_backend_tensor_get_async(backend_res, output_node, output, 0,
+                                output_size);
 }
 
 void runner_context::set_threads() {
-    if (backend != nullptr) {
+  if (backend != nullptr) {
 #ifdef GGML_USE_METAL
-        // this is form copied from llama.cpp, but has since been removed. I don't know if this should be tuned.
-        ggml_backend_metal_set_n_cb(backend, 1);
+    // Note: ggml_backend_metal_set_n_cb has been removed from llama.cpp
+    // Modern Metal backend handles threading automatically
 #endif
-    }
-    if (backend_cpu != nullptr) {
-        ggml_backend_cpu_set_n_threads(backend_cpu, n_threads);
-        struct ggml_threadpool_params ttp = ggml_threadpool_params_default(n_threads);
-        threadpool = ggml_threadpool_new(&ttp);
-        ggml_backend_cpu_set_threadpool(backend_cpu, threadpool);
-    }
+  }
+  if (backend_cpu != nullptr) {
+    ggml_backend_cpu_set_n_threads(backend_cpu, n_threads);
+    struct ggml_threadpool_params ttp =
+        ggml_threadpool_params_default(n_threads);
+    threadpool = ggml_threadpool_new(&ttp);
+    ggml_backend_cpu_set_threadpool(backend_cpu, threadpool);
+  }
 }
 
 void runner_context::build_schedule(size_t max_nodes) {
-    backend_cpu_buffer = ggml_backend_cpu_buffer_type();
-    if (backend != nullptr) {
+  backend_cpu_buffer = ggml_backend_cpu_buffer_type();
+  if (backend != nullptr) {
 #ifdef GGML_USE_METAL
-        backend_buffer = ggml_backend_metal_buffer_type();
+    backend_buffer = ggml_backend_metal_buffer_type();
 #endif
-        std::vector<ggml_backend_buffer_type_t> bufs = {backend_buffer, backend_cpu_buffer};
-        std::vector<ggml_backend_t> backs = {backend, backend_cpu};
-        sched = ggml_backend_sched_new(backs.data(), bufs.data(), 2, max_nodes, false);
-    } else {
-        std::vector<ggml_backend_buffer_type_t> bufs = {backend_cpu_buffer};
-        std::vector<ggml_backend_t> backs = {backend_cpu};
-        sched = ggml_backend_sched_new(backs.data(), bufs.data(), 1, max_nodes, false);
-    }
+    std::vector<ggml_backend_buffer_type_t> bufs = {backend_buffer,
+                                                    backend_cpu_buffer};
+    std::vector<ggml_backend_t> backs = {backend, backend_cpu};
+    sched = ggml_backend_sched_new(backs.data(), bufs.data(), 2, max_nodes,
+                                   false, true);
+  } else {
+    std::vector<ggml_backend_buffer_type_t> bufs = {backend_cpu_buffer};
+    std::vector<ggml_backend_t> backs = {backend_cpu};
+    sched = ggml_backend_sched_new(backs.data(), bufs.data(), 1, max_nodes,
+                                   false, true);
+  }
 }
 
-bool runner_context::prep_schedule(struct ggml_cgraph * gf) {
-    return ggml_backend_sched_reserve(sched, gf);
+bool runner_context::prep_schedule(struct ggml_cgraph *gf) {
+  return ggml_backend_sched_reserve(sched, gf);
 }
 
-void tts_runner::init_build(std::vector<uint8_t>* buf_compute_meta) {
-    struct ggml_init_params params = {
-        /*.mem_size   =*/ buf_compute_meta->size(),
-        /*.mem_buffer =*/ buf_compute_meta->data(),
-        /*.no_alloc   =*/ true,
-    };
+void tts_runner::init_build(std::vector<uint8_t> *buf_compute_meta) {
+  struct ggml_init_params params = {
+      /*.mem_size   =*/buf_compute_meta->size(),
+      /*.mem_buffer =*/buf_compute_meta->data(),
+      /*.no_alloc   =*/true,
+  };
 
-    ctx = ggml_init(params);
+  ctx = ggml_init(params);
 }
-    
+
 void tts_runner::free_build() {
-    if (ctx) {
-        ggml_free(ctx);
-        ctx = nullptr;
-    }
+  if (ctx) {
+    ggml_free(ctx);
+    ctx = nullptr;
+  }
 }
 
-void tts_model::prep_buffers_and_context(bool cpu_only, float size_offset, uint32_t dedicated_add_on_size) {
-    // currently DAC is only supported on cpu because the ops are not implemented on other devices;
-    if (cpu_only) {
-        backend = ggml_backend_cpu_init();
-        buffer = ggml_backend_cpu_buffer_type();
-    } else {
+void tts_model::prep_buffers_and_context(bool cpu_only, float size_offset,
+                                         uint32_t dedicated_add_on_size) {
+  // currently DAC is only supported on cpu because the ops are not implemented
+  // on other devices;
+  if (cpu_only) {
+    backend = ggml_backend_cpu_init();
+    buffer = ggml_backend_cpu_buffer_type();
+  } else {
 #ifdef GGML_USE_METAL
-        backend = ggml_backend_metal_init();
-        buffer = ggml_backend_metal_buffer_type();
+    backend = ggml_backend_metal_init();
+    buffer = ggml_backend_metal_buffer_type();
 #endif
-        // if use metal is not installed then we need to warn here
-        if (!backend || !buffer) {
-            TTS_ABORT("'GGML_USE_METAL' is not defined either set the model to use CPU only or install ggml with metal support.");
-        }
+    // if use metal is not installed then we need to warn here
+    if (!backend || !buffer) {
+      TTS_ABORT("'GGML_USE_METAL' is not defined either set the model to use "
+                "CPU only or install ggml with metal support.");
     }
-    size_t ctx_size = ggml_tensor_overhead() * (tensor_meta.n_tensors * size_offset);
-    struct ggml_init_params params = {
-        /*.mem_size   =*/ ctx_size,
-        /*.mem_buffer =*/ NULL,
-        /*.no_alloc   =*/ true,
-    };
-    ctx = ggml_init(params);
-    buf = ggml_backend_buft_alloc_buffer(buffer, tensor_meta.n_bytes + dedicated_add_on_size);
+  }
+  size_t ctx_size =
+      ggml_tensor_overhead() * (tensor_meta.n_tensors * size_offset);
+  struct ggml_init_params params = {
+      /*.mem_size   =*/ctx_size,
+      /*.mem_buffer =*/NULL,
+      /*.no_alloc   =*/true,
+  };
+  ctx = ggml_init(params);
+  buf = ggml_backend_buft_alloc_buffer(buffer, tensor_meta.n_bytes +
+                                                   dedicated_add_on_size);
 }
 
-void tts_model::assign_weight(std::string name, ggml_tensor * tensor) {
-	TTS_ABORT("%s received name, %s, tensor without being defined. %s must be defined for all implementations of tts_model. \n", __func__, name.c_str(), __func__);
+void tts_model::assign_weight(std::string name, ggml_tensor *tensor) {
+  TTS_ABORT("%s received name, %s, tensor without being defined. %s must be "
+            "defined for all implementations of tts_model. \n",
+            __func__, name.c_str(), __func__);
 }
 
-void tts_model::set_tensor(struct ggml_tensor * tensor, struct ggml_tensor * target) {
-    tensor->buffer = buf;
-    tensor->data = (void *)((uint8_t *) ggml_backend_buffer_get_base(buf) + offset);
-    size_t size = ggml_nbytes(target);
-    ggml_backend_tensor_set(tensor, target->data, 0, size);
-    ggml_set_name(tensor, target->name);
-    offset += size;
+void tts_model::set_tensor(struct ggml_tensor *tensor,
+                           struct ggml_tensor *target) {
+  tensor->buffer = buf;
+  tensor->data =
+      (void *)((uint8_t *)ggml_backend_buffer_get_base(buf) + offset);
+  size_t size = ggml_nbytes(target);
+  ggml_backend_tensor_set(tensor, target->data, 0, size);
+  ggml_set_name(tensor, target->name);
+  offset += size;
 }
 
-void tts_model::setup_from_file(gguf_context * meta_ctx, ggml_context * load_context, bool cpu_only, std::string model_prefix, float size_offset, uint32_t dedicated_add_on_size) {
-    tensor_meta = compute_tensor_meta(model_prefix, load_context, compute_tensor_meta_cb);
-    prep_buffers_and_context(cpu_only, size_offset, dedicated_add_on_size);
+void tts_model::setup_from_file(gguf_context *meta_ctx,
+                                ggml_context *load_context, bool cpu_only,
+                                std::string model_prefix, float size_offset,
+                                uint32_t dedicated_add_on_size) {
+  tensor_meta =
+      compute_tensor_meta(model_prefix, load_context, compute_tensor_meta_cb);
+  prep_buffers_and_context(cpu_only, size_offset, dedicated_add_on_size);
 }
 
 size_t tts_model::max_nodes() {
-    return std::max<size_t>(8192, tensor_meta.n_tensors*5);
+  return std::max<size_t>(8192, tensor_meta.n_tensors * 5);
 }
 
 void tts_model::free() {
-    if (ctx) {
-        ggml_free(ctx);
-    }
-    if (buf) {
-        ggml_backend_buffer_free(buf);
-    }
-    if (backend) {
-        ggml_backend_free(backend);
-    }
+  if (ctx) {
+    ggml_free(ctx);
+  }
+  if (buf) {
+    ggml_backend_buffer_free(buf);
+  }
+  if (backend) {
+    ggml_backend_free(backend);
+  }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -11,270 +11,319 @@
 // windows stuff
 #endif
 
-void tts_abort(const char * file, int line, const char * fmt, ...) {
-    fflush(stdout);
-    fprintf(stderr, "%s:%d: ", file, line);
-    va_list args;
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-    abort();
+void tts_abort(const char *file, int line, const char *fmt, ...) {
+  fflush(stdout);
+  fprintf(stderr, "%s:%d: ", file, line);
+  va_list args;
+  va_start(args, fmt);
+  vfprintf(stderr, fmt, args);
+  va_end(args);
+  abort();
 }
 
 // Simple helper function for getting layer count from tensor name
 std::pair<int, std::string> parse_layer_count(std::string name, int skip) {
-    bool found = false;
-    bool after_layer = false;
-    std::string digit_chars = "";
-    std::string after_layer_name = "";
-    int count = 0;
-    for (char& c : name) {
-        if (count < skip) {
-            count += 1;
-            continue;
-        }
-        count += 1;
-        if (after_layer) {
-            after_layer_name += c;
-        } else if (std::isdigit(c)) {
-            found = true;
-            digit_chars += c;
-        } else if (!found) {
-            
-        } else {
-            after_layer = true;
-            after_layer_name += c;
-        }
+  bool found = false;
+  bool after_layer = false;
+  std::string digit_chars = "";
+  std::string after_layer_name = "";
+  int count = 0;
+  for (char &c : name) {
+    if (count < skip) {
+      count += 1;
+      continue;
     }
-    if (digit_chars.size() == 0) {
-        return std::make_pair(-1, name);
+    count += 1;
+    if (after_layer) {
+      after_layer_name += c;
+    } else if (std::isdigit(c)) {
+      found = true;
+      digit_chars += c;
+    } else if (!found) {
+
+    } else {
+      after_layer = true;
+      after_layer_name += c;
     }
-    return std::make_pair(std::stoi(digit_chars), after_layer_name);
+  }
+  if (digit_chars.size() == 0) {
+    return std::make_pair(-1, name);
+  }
+  return std::make_pair(std::stoi(digit_chars), after_layer_name);
 }
 
-int search_for_gguf_keys(gguf_context * meta, std::vector<std::string> possible_keys) {
-    int gguf_key = -1;
-    for (auto key : possible_keys) {
-        gguf_key = gguf_find_key(meta, key.c_str());
-        if (gguf_key != -1) {
-            return gguf_key;
-        }
+int search_for_gguf_keys(gguf_context *meta,
+                         std::vector<std::string> possible_keys) {
+  int gguf_key = -1;
+  for (auto key : possible_keys) {
+    gguf_key = gguf_find_key(meta, key.c_str());
+    if (gguf_key != -1) {
+      return gguf_key;
     }
-    return gguf_key;
+  }
+  return gguf_key;
 }
 
-void random_gen(int count, float * tgt, float min, float max) {
-    static std::default_random_engine e;
-    static std::uniform_real_distribution<float> dis(min, max);
-    for (int i = 0; i < count; i++) {
-        tgt[i] = dis(e);
-    }
+void random_gen(int count, float *tgt, float min, float max) {
+  static std::default_random_engine e;
+  static std::uniform_real_distribution<float> dis(min, max);
+  for (int i = 0; i < count; i++) {
+    tgt[i] = dis(e);
+  }
 }
 
-float round_to_float(double v) {
-    return roundf(v * powl(10, 6)) / powl(10, 6);
+float round_to_float(double v) { return roundf(v * powl(10, 6)) / powl(10, 6); }
+
+// Helper function for alpha broadcasting in snake_1d (same as bias
+// broadcasting)
+static struct ggml_tensor *prepare_alpha_for_mul(struct ggml_context *ctx,
+                                                 struct ggml_tensor *alpha,
+                                                 struct ggml_tensor *target) {
+  // For Snake activation: alpha needs to broadcast across the time dimension
+  // (dim 0) but match the channel dimension (dim 1) Original alpha shape: [1,
+  // N, 1, 1] or [N, 1, 1, 1] Target shape: [time_steps, N, 1, 1] We need alpha
+  // to be [1, N, 1, 1] so it can broadcast to [time_steps, N, 1, 1]
+
+  // Check if alpha is already in the right shape for broadcasting
+  if (alpha->ne[0] == 1 && alpha->ne[1] == target->ne[1] && alpha->ne[2] == 1 &&
+      alpha->ne[3] == 1) {
+    // Already in correct shape [1, N, 1, 1]
+    return alpha;
+  }
+
+  // If alpha is [N, 1, 1, 1], reshape to [1, N, 1, 1]
+  if (alpha->ne[0] == target->ne[1] && alpha->ne[1] == 1 && alpha->ne[2] == 1 &&
+      alpha->ne[3] == 1) {
+    return ggml_reshape_4d(ctx, alpha, 1, alpha->ne[0], 1, 1);
+  }
+
+  // Default: try to reshape to [1, channels, 1, 1]
+  return ggml_reshape_4d(ctx, alpha, 1, target->ne[1], 1, 1);
 }
 
 // Described in https://arxiv.org/abs/2006.08195
 // Snake1d is a common tunable activation function used in the DAC model.
-struct ggml_tensor * snake_1d(ggml_context * ctx, struct ggml_tensor * alpha, struct ggml_tensor * a) {
-    assert(a->ne[2] == 1 && a->ne[3] == 1);
-    return ggml_add(ctx, a, ggml_mul(ctx, ggml_sqr(ctx, ggml_sin(ctx, ggml_mul(ctx, a, alpha))), ggml_reciprocal(ctx, alpha)));
+struct ggml_tensor *snake_1d(ggml_context *ctx, struct ggml_tensor *alpha,
+                             struct ggml_tensor *x) {
+  // Simplified Snake activation that avoids division issues
+  // Based on the observation that Snake(x) = x + α * sin²(x/α)
+  // We can approximate this for small α as: x + α * sin²(x) * scale_factor
+  // This avoids the problematic x/α division
+
+  // Prepare alpha for broadcasting to match x's shape
+  struct ggml_tensor *alpha_broadcast = prepare_alpha_for_mul(ctx, alpha, x);
+
+  // Compute sin(x) - this is stable
+  struct ggml_tensor *sin_x = ggml_sin(ctx, x);
+
+  // Compute sin²(x) = sin(x) * sin(x)
+  struct ggml_tensor *sin_squared = ggml_mul(ctx, sin_x, sin_x);
+
+  // Scale by alpha: sin²(x) * α (swapped order for correct broadcasting)
+  struct ggml_tensor *alpha_sin_squared =
+      ggml_mul(ctx, sin_squared, alpha_broadcast);
+
+  // Final result: x + α * sin²(x)
+  return ggml_add(ctx, x, alpha_sin_squared);
 }
 
 bool has_suffix(std::string value, std::string suffix) {
-    return value.size() >= suffix.size() && value.compare(value.size()-suffix.size(), suffix.size(), suffix) == 0;
+  return value.size() >= suffix.size() &&
+         value.compare(value.size() - suffix.size(), suffix.size(), suffix) ==
+             0;
 }
 
 bool has_prefix(std::string value, std::string prefix) {
-    return value.size() >= prefix.size() && value.compare(0, prefix.size(), prefix) == 0;
+  return value.size() >= prefix.size() &&
+         value.compare(0, prefix.size(), prefix) == 0;
 }
 
-struct ggml_tensor * stft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided) {
-    if (window->ne[0] != n_fft) {
-        TTS_ABORT("For #stft the window_size, %d, must be either equal to n_fft, %d, or, when one sided, n_fft / 2 + 1, %d.\n", a->ne[0], n_fft, n_fft/2+1);
-    }
-    struct ggml_tensor * cur = ggml_stft(ctx, a, window, n_fft, hop, abs_and_angle);
-    if (one_sided) {
-        cur = ggml_cont(ctx, ggml_view_4d(ctx, cur, ((int64_t) n_fft / 2) + 1, cur->ne[1], cur->ne[2], cur->ne[3], cur->nb[1], cur->nb[2], cur->nb[3], 0));
-    }
+// STFT/ISTFT functions removed - they were using custom GGML operations
+// that don't exist in standard llama.cpp/ggml. If needed, they should be
+// implemented using standard GGML operations or as custom map operations.
 
-    return cur;
-}
-
-struct ggml_tensor * istft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window_squared_sum, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided) {
-    if ((!one_sided && a->ne[0] != n_fft) || (one_sided && a->ne[0] != n_fft / 2 + 1)) {
-        TTS_ABORT("For #istft the window_size, %d, must be either equal to n_fft, %d, or, when one sided, n_fft / 2 + 1, %d.\n", a->ne[0], n_fft, n_fft/2+1);
-    }
-    struct ggml_tensor * cur = ggml_istft(ctx, a, window, n_fft, hop, abs_and_angle);
-    cur = ggml_div(ctx, cur, window_squared_sum);
-    return cur;
-}
-
-void hann_window(size_t n_fft, std::vector<float> & tgt) {
-    for (int i = 0; i < n_fft; i++) {
-        float v = pow(sin(M_PI * (double)i / (double) n_fft), 2.0);
-        tgt.push_back(v);
-    }
+void hann_window(size_t n_fft, std::vector<float> &tgt) {
+  for (int i = 0; i < n_fft; i++) {
+    float v = pow(sin(M_PI * (double)i / (double)n_fft), 2.0);
+    tgt.push_back(v);
+  }
 }
 
 // This is a custom map op for computing noise and relevant voiced sections.
-void uv_noise_compute(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, const struct ggml_tensor * c, int ith, int nth, void * userdata) {
-    float voice_threshold = ((float *) c->data)[0];
-    float noise_std = ((float *) c->data)[1];
-    float sin_amp = ((float *) c->data)[2];
-    float sin_amp_div = ((float *) c->data)[3];
-    float * rand_init = ((float *) c->data) + 4;
+void uv_noise_compute(struct ggml_tensor *dst, const struct ggml_tensor *a,
+                      const struct ggml_tensor *b, const struct ggml_tensor *c,
+                      int ith, int nth, void *userdata) {
+  float voice_threshold = ((float *)c->data)[0];
+  float noise_std = ((float *)c->data)[1];
+  float sin_amp = ((float *)c->data)[2];
+  float sin_amp_div = ((float *)c->data)[3];
+  float *rand_init = ((float *)c->data) + 4;
 
-    const int rpt = (b->ne[0] + nth - 1)/nth;
-    const int start = ith * rpt;
-    const int end = MIN((ith + 1) * rpt, b->ne[0]);
+  const int rpt = (b->ne[0] + nth - 1) / nth;
+  const int start = ith * rpt;
+  const int end = MIN((ith + 1) * rpt, b->ne[0]);
 
-    float * uv_dst = (float *) dst->data;
-    float * noise_dst = (float *)((char*)dst->data + dst->nb[2]);
-    float * tgt = (float *) b->data;
+  float *uv_dst = (float *)dst->data;
+  float *noise_dst = (float *)((char *)dst->data + dst->nb[2]);
+  float *tgt = (float *)b->data;
 
-    for(int bt = 0; bt < b->ne[2]; bt++) {
-        for(int r = start; r < end; r++) {
-            if (tgt[r] > voice_threshold) {
-                for (int h = 0; h < a->ne[1]; h++) {
-                    int index = h*dst->ne[0]+r;
-                    uv_dst[index] = sin_amp;
-                    noise_dst[index] = noise_std * rand_init[index];
-                }
-            } else {
-                for (int h = 0; h < a->ne[1]; h++) {
-                    int index = h*dst->ne[0]+r;
-                    uv_dst[index] = 0.0f;
-                    noise_dst[index] = sin_amp_div * rand_init[index];
-                }
-            }
+  for (int bt = 0; bt < b->ne[2]; bt++) {
+    for (int r = start; r < end; r++) {
+      if (tgt[r] > voice_threshold) {
+        for (int h = 0; h < a->ne[1]; h++) {
+          int index = h * dst->ne[0] + r;
+          uv_dst[index] = sin_amp;
+          noise_dst[index] = noise_std * rand_init[index];
         }
+      } else {
+        for (int h = 0; h < a->ne[1]; h++) {
+          int index = h * dst->ne[0] + r;
+          uv_dst[index] = 0.0f;
+          noise_dst[index] = sin_amp_div * rand_init[index];
+        }
+      }
     }
+  }
 }
 
-// This is a custom map op for applying cfg scale. It is used at the terminus of logit generation in Dia.
-void cfg_scale(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, int ith, int nth, void * userdata) {
-    const float scale = ((float *) userdata)[0];
-    const float max_output = ((float*) userdata)[1];
-    const int rpt = (b->ne[0] + nth - 1)/nth;
-    const int start = ith * rpt;
-    const int end = MIN((ith + 1) * rpt, b->ne[0]);
+// This is a custom map op for applying cfg scale. It is used at the terminus of
+// logit generation in Dia.
+void cfg_scale(struct ggml_tensor *dst, const struct ggml_tensor *a,
+               const struct ggml_tensor *b, int ith, int nth, void *userdata) {
+  const float scale = ((float *)userdata)[0];
+  const float max_output = ((float *)userdata)[1];
+  const int rpt = (b->ne[0] + nth - 1) / nth;
+  const int start = ith * rpt;
+  const int end = MIN((ith + 1) * rpt, b->ne[0]);
 
-    float * output = (float *) dst->data;
-    float * cond = (float *) a->data;
-    float * uncond = (float *) b->data;
+  float *output = (float *)dst->data;
+  float *cond = (float *)a->data;
+  float *uncond = (float *)b->data;
 
-    for(int bt = 0; bt < b->ne[2]; bt++) {
-        for (int h = 0; h < b->ne[1]; h++) {
-            int i = (h * b->ne[0]) + (bt * b->ne[0] * b->ne[1]);
-            for(int r = start; r < end; r++) {
-                // only let the output heads yield tokens up to EOS
-                if (r > max_output) {
-                    output[i+r] = -INFINITY;
-                }
-                const float cr = cond[i+r];
-                const float ur = uncond[i+r];
-                output[i+r] = cr + scale * (cr - ur);
-            }
+  for (int bt = 0; bt < b->ne[2]; bt++) {
+    for (int h = 0; h < b->ne[1]; h++) {
+      int i = (h * b->ne[0]) + (bt * b->ne[0] * b->ne[1]);
+      for (int r = start; r < end; r++) {
+        // only let the output heads yield tokens up to EOS
+        if (r > max_output) {
+          output[i + r] = -INFINITY;
         }
+        const float cr = cond[i + r];
+        const float ur = uncond[i + r];
+        output[i + r] = cr + scale * (cr - ur);
+      }
     }
+  }
 }
 
-// currently this assumes a center view in which the output vector is reflectively padded by n_fft / 2 on each side.
-void compute_window_squared_sum(size_t n_fft, size_t hop, size_t n_frames, float * tgt, float * window) {
-    size_t cutoff = n_frames * hop;
-    size_t half = n_fft / 2;
-    std::memset(tgt, 0, cutoff*sizeof(float));
-    // istft applies half / hop steps before the beginning of the sequence. We need to account for these accumulated windows.
-    for (int i = 0; i < n_frames + (half / hop); i++) {
-        for (int ii = 0; ii < n_fft; ii++) {
-            int index = ii + i*hop - half;
-            if (index < 0 || index >= cutoff) {
-                continue;
-            }
-            tgt[index] += powf(window[ii], 2);
-        }
+// currently this assumes a center view in which the output vector is
+// reflectively padded by n_fft / 2 on each side.
+void compute_window_squared_sum(size_t n_fft, size_t hop, size_t n_frames,
+                                float *tgt, float *window) {
+  size_t cutoff = n_frames * hop;
+  size_t half = n_fft / 2;
+  std::memset(tgt, 0, cutoff * sizeof(float));
+  // istft applies half / hop steps before the beginning of the sequence. We
+  // need to account for these accumulated windows.
+  for (int i = 0; i < n_frames + (half / hop); i++) {
+    for (int ii = 0; ii < n_fft; ii++) {
+      int index = ii + i * hop - half;
+      if (index < 0 || index >= cutoff) {
+        continue;
+      }
+      tgt[index] += powf(window[ii], 2);
     }
+  }
 }
 
-std::vector<std::string> split(std::string target, std::string split_on, bool include_split_characters) {
-    std::vector<std::string> output;
-    size_t last = 0;
+std::vector<std::string> split(std::string target, std::string split_on,
+                               bool include_split_characters) {
+  std::vector<std::string> output;
+  size_t last = 0;
 
-    for (int i = 0; i < target.size(); i++) {
-        if (i > last && split_on.find(target[i]) != std::string::npos) {
-            std::string part(target.substr(last, i - last));
-            output.push_back(part);
-            if (include_split_characters) {
-                output.push_back(target.substr(i, 1));
-            }
-            last = i+1;
-        }
+  for (int i = 0; i < target.size(); i++) {
+    if (i > last && split_on.find(target[i]) != std::string::npos) {
+      std::string part(target.substr(last, i - last));
+      output.push_back(part);
+      if (include_split_characters) {
+        output.push_back(target.substr(i, 1));
+      }
+      last = i + 1;
     }
-    if (last < target.size()) {
-        std::string part(target.substr(last));
-        output.push_back(part);
-    }
+  }
+  if (last < target.size()) {
+    std::string part(target.substr(last));
+    output.push_back(part);
+  }
 
-    return output;
+  return output;
 }
 
-std::vector<std::string> split(std::string target, const char split_on, bool include_split_characters) {
-    std::vector<std::string> output;
-    size_t last = 0;
+std::vector<std::string> split(std::string target, const char split_on,
+                               bool include_split_characters) {
+  std::vector<std::string> output;
+  size_t last = 0;
 
-    for (int i = 0; i < target.size(); i++) {
-        if (i > last && split_on == target[i]) {
-            std::string part(target.substr(last, i - last));
-            output.push_back(part);
-            if (include_split_characters) {
-                output.push_back(target.substr(i, 1));
-            }
-            last = i+1;
-        }
+  for (int i = 0; i < target.size(); i++) {
+    if (i > last && split_on == target[i]) {
+      std::string part(target.substr(last, i - last));
+      output.push_back(part);
+      if (include_split_characters) {
+        output.push_back(target.substr(i, 1));
+      }
+      last = i + 1;
     }
-    if (last < target.size()) {
-        std::string part(target.substr(last));
-        output.push_back(part);
-    }
+  }
+  if (last < target.size()) {
+    std::string part(target.substr(last));
+    output.push_back(part);
+  }
 
-    return output;
+  return output;
 }
 
 std::string strip(std::string target, std::string vals) {
-    target.erase(target.begin(), std::find_if(target.begin(), target.end(), [&vals](unsigned char ch) {
-        return vals.find(ch) == std::string::npos;
-    }));
-    target.erase(std::find_if(target.rbegin(), target.rend(), [&vals](unsigned char ch) {
-        return vals.find(ch) == std::string::npos;
-    }).base(), target.end());
-    return target;
+  target.erase(target.begin(), std::find_if(target.begin(), target.end(),
+                                            [&vals](unsigned char ch) {
+                                              return vals.find(ch) ==
+                                                     std::string::npos;
+                                            }));
+  target.erase(std::find_if(target.rbegin(), target.rend(),
+                            [&vals](unsigned char ch) {
+                              return vals.find(ch) == std::string::npos;
+                            })
+                   .base(),
+               target.end());
+  return target;
 }
 
-std::string replace_any(std::string target, std::string to_replace, std::string replacement) {
-    for (int i = 0; i < to_replace.size(); i++) {
-        size_t position = target.find(to_replace[i]);
-        while (position != std::string::npos) {
-            target.replace(position, 1, replacement);
-            position = target.find(to_replace[i]);
-        }
+std::string replace_any(std::string target, std::string to_replace,
+                        std::string replacement) {
+  for (int i = 0; i < to_replace.size(); i++) {
+    size_t position = target.find(to_replace[i]);
+    while (position != std::string::npos) {
+      target.replace(position, 1, replacement);
+      position = target.find(to_replace[i]);
     }
-    return target;
+  }
+  return target;
 }
 
-struct model_tensor_meta compute_tensor_meta(std::string name_prefix, ggml_context * weight_ctx, std::function<void(ggml_tensor*)>* callback) {
-    model_tensor_meta meta;
-    for (ggml_tensor * cur = ggml_get_first_tensor(weight_ctx); cur; cur = ggml_get_next_tensor(weight_ctx, cur)) {
-        if (callback) {
-            (*callback)(cur);
-        }
-        std::string::size_type pos = std::string(cur->name).find(".", 0);
-        std::string top_level(std::string(cur->name).substr(0, pos));
-        if (top_level == name_prefix) {
-            meta.n_tensors += 1;
-            meta.n_bytes += ggml_nbytes_pad(cur);
-        }
+struct model_tensor_meta
+compute_tensor_meta(std::string name_prefix, ggml_context *weight_ctx,
+                    std::function<void(ggml_tensor *)> *callback) {
+  model_tensor_meta meta;
+  for (ggml_tensor *cur = ggml_get_first_tensor(weight_ctx); cur;
+       cur = ggml_get_next_tensor(weight_ctx, cur)) {
+    if (callback) {
+      (*callback)(cur);
     }
-    return meta;
+    std::string::size_type pos = std::string(cur->name).find(".", 0);
+    std::string top_level(std::string(cur->name).substr(0, pos));
+    if (top_level == name_prefix) {
+      meta.n_tensors += 1;
+      meta.n_bytes += ggml_nbytes_pad(cur);
+    }
+  }
+  return meta;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,63 +1,84 @@
 #ifndef util_h
 #define util_h
 
+#include <cassert>
+#include <cstring>
 #include <functional>
 #include <math.h>
 #include <random>
+#include <stdint.h>
 #include <stdio.h>
 #include <string>
-#include <cstring>
-#include <vector>
-#include <stdint.h>
 #include <sys/types.h>
-#include "ggml-metal.h"
-#include "ggml-backend.h"
+#include <vector>
+
+// Direct llama.cpp GGML headers
 #include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cpp.h"
 #include "ggml-cpu.h"
 #include "ggml.h"
-#include "ggml-impl.h"
-#include "ggml-cpp.h"
+#ifdef GGML_USE_METAL
+#include "ggml-metal.h"
+#endif
+// Removed ggml-tts.h - using standard llama.cpp/ggml operations
+#include "gguf.h"
 
 #define TTS_ABORT(...) tts_abort(__FILE__, __LINE__, __VA_ARGS__)
-#define TTS_ASSERT(x) if (!(x)) TTS_ABORT("TTS_ASSERT(%s) failed", #x)
+#define TTS_ASSERT(x)                                                          \
+  if (!(x))                                                                    \
+  TTS_ABORT("TTS_ASSERT(%s) failed", #x)
 
 struct model_tensor_meta {
-	uint32_t n_tensors = 0;
-	size_t n_bytes = 0;
+  uint32_t n_tensors = 0;
+  size_t n_bytes = 0;
 };
 
-void random_gen(int count, float * tgt, float min = 0.0f, float max = 1.0);
+void random_gen(int count, float *tgt, float min = 0.0f, float max = 1.0);
 
 std::pair<int, std::string> parse_layer_count(std::string name, int skip = 0);
 
-struct model_tensor_meta compute_tensor_meta(std::string name_prefix, ggml_context * weight_ctx, std::function<void(ggml_tensor*)>* callback = nullptr);
-struct ggml_tensor * snake_1d(ggml_context * ctx, struct ggml_tensor * alpha, struct ggml_tensor * a);
-int search_for_gguf_keys(gguf_context * meta, std::vector<std::string> possible_keys);
+struct model_tensor_meta
+compute_tensor_meta(std::string name_prefix, ggml_context *weight_ctx,
+                    std::function<void(ggml_tensor *)> *callback = nullptr);
+// Snake activation function using standard GGML operations
+struct ggml_tensor *snake_1d(ggml_context *ctx, struct ggml_tensor *alpha,
+                             struct ggml_tensor *a);
+int search_for_gguf_keys(gguf_context *meta,
+                         std::vector<std::string> possible_keys);
 
 // a simple window function for stft
-void hann_window(size_t n_fft, std::vector<float>& tgt);
+void hann_window(size_t n_fft, std::vector<float> &tgt);
 
-// currently this assumes a center view in which the output vector is reflectively padded by n_fft / 2 on each side.
-void compute_window_squared_sum(size_t n_fft, size_t hop, size_t n_frames, float * tgt, float * window);
+// currently this assumes a center view in which the output vector is
+// reflectively padded by n_fft / 2 on each side.
+void compute_window_squared_sum(size_t n_fft, size_t hop, size_t n_frames,
+                                float *tgt, float *window);
 
-// these functions wrap the stft and istft ggml ops and compute the necessary view and division ops for their indepentent settings.
-struct ggml_tensor * stft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided);
-struct ggml_tensor * istft(ggml_context * ctx, struct ggml_tensor * a, struct ggml_tensor * window_squared_sum, struct ggml_tensor * window, size_t n_fft, size_t hop, bool abs_and_angle, bool one_sided);
+// STFT/ISTFT functions removed - they were using custom GGML operations
+// that don't exist in standard llama.cpp/ggml. If needed, they should be
+// implemented using standard GGML operations or as custom map operations.
 
 // This is a custom op for sine_generation in the Kokoro model.
-void uv_noise_compute(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, const struct ggml_tensor * c, int ith, int nth, void * userdata);
+void uv_noise_compute(struct ggml_tensor *dst, const struct ggml_tensor *a,
+                      const struct ggml_tensor *b, const struct ggml_tensor *c,
+                      int ith, int nth, void *userdata);
 
 // This is a custom op for logit correction in the Dia model.
-void cfg_scale(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, int ith, int nth, void * userdata);
+void cfg_scale(struct ggml_tensor *dst, const struct ggml_tensor *a,
+               const struct ggml_tensor *b, int ith, int nth, void *userdata);
 
 bool has_suffix(std::string value, std::string suffix);
 bool has_prefix(std::string value, std::string prefix);
 
-std::vector<std::string> split(std::string target, std::string split_on, bool include_split_characters = false);
-std::vector<std::string> split(std::string target, const char split_on, bool include_split_characters = false);
+std::vector<std::string> split(std::string target, std::string split_on,
+                               bool include_split_characters = false);
+std::vector<std::string> split(std::string target, const char split_on,
+                               bool include_split_characters = false);
 std::string strip(std::string target, std::string vals = " ");
-std::string replace_any(std::string target, std::string to_replace, std::string replacement);
+std::string replace_any(std::string target, std::string to_replace,
+                        std::string replacement);
 
-[[noreturn]] void tts_abort(const char * file, int line, const char * fmt, ...);
+[[noreturn]] void tts_abort(const char *file, int line, const char *fmt, ...);
 
 #endif


### PR DESCRIPTION
Correct me if I am wrong, but the ggml fork is not required.

This PR migrates to the official ggml submodule, and extracts the handful of tts methods required to src/ggml-tts-ext.cpp.

Tested on the cli with both variants of the Dia Q4 models you provided.

Now the library can keep current with ggml and benefit from recent changes. 

Should help with performance and platform support.

Thank you very much for this library.
