### PR TITLE
Reciprocal stride hack

### DIFF
--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -50,6 +50,7 @@ struct tts_model {
     ggml_backend_t backend = nullptr;
     ggml_backend_buffer_t buf = nullptr;
 
+
     // it is quite common for implementations of tts_model to need to update attributes or perform distinct operations
     // when computing the tensor meta of the loaded model. This callback allows this as it will receive each processed tensor.
     tensor_meta_callback compute_tensor_meta_cb = nullptr;

--- a/src/tts_model.h
+++ b/src/tts_model.h
@@ -50,7 +50,6 @@ struct tts_model {
     ggml_backend_t backend = nullptr;
     ggml_backend_buffer_t buf = nullptr;
 
-
     // it is quite common for implementations of tts_model to need to update attributes or perform distinct operations
     // when computing the tensor meta of the loaded model. This callback allows this as it will receive each processed tensor.
     tensor_meta_callback compute_tensor_meta_cb = nullptr;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -75,11 +75,21 @@ float round_to_float(double v) {
     return roundf(v * powl(10, 6)) / powl(10, 6);
 }
 
+struct ggml_tensor * reciprocal(ggml_context * ctx, struct ggml_tensor * x) {
+    TTS_ASSERT(x->ne[0] == 1);
+    static constexpr float one = 1.0f;
+    ggml_tensor * numerator = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, 1, x->ne[1]);
+    // stride hack so that the scalar numerator can be divided by x;
+    numerator->nb[1] = 0;
+    numerator->data = const_cast<float *>(&one);
+    return ggml_div(ctx, numerator, x);
+}
+
 // Described in https://arxiv.org/abs/2006.08195
 // Snake1d is a common tunable activation function used in the DAC model.
 struct ggml_tensor * snake_1d(ggml_context * ctx, struct ggml_tensor * alpha, struct ggml_tensor * a) {
     assert(a->ne[2] == 1 && a->ne[3] == 1);
-    return ggml_add(ctx, a, ggml_mul(ctx, ggml_sqr(ctx, ggml_sin(ctx, ggml_mul(ctx, a, alpha))), ggml_reciprocal(ctx, alpha)));
+    return ggml_add(ctx, a, ggml_mul(ctx, ggml_sqr(ctx, ggml_sin(ctx, ggml_mul(ctx, a, alpha))), reciprocal(ctx, alpha)));
 }
 
 bool has_suffix(std::string value, std::string suffix) {

--- a/src/util.h
+++ b/src/util.h
@@ -50,6 +50,8 @@ void uv_noise_compute(struct ggml_tensor * dst, const struct ggml_tensor * a, co
 // This is a custom op for logit correction in the Dia model.
 void cfg_scale(struct ggml_tensor * dst, const struct ggml_tensor * a, const struct ggml_tensor * b, int ith, int nth, void * userdata);
 
+struct ggml_tensor * ggml_reciprocal(ggml_context * ctx, struct ggml_tensor * x);
+
 bool has_suffix(std::string value, std::string suffix);
 bool has_prefix(std::string value, std::string prefix);
 


### PR DESCRIPTION
Removes the immediate need to upstream `ggml_reciprocal`.