### PR TITLE
cli: Rename to tts-cli

### DIFF
--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_executable(cli
+set(TARGET tts-cli)
+
+add_executable(${TARGET}
     cli.cpp
     playback.cpp
     playback.h
@@ -10,8 +12,8 @@ add_executable(cli
 
 find_package(SDL2)
 if (SDL2_FOUND)
-    target_link_libraries(cli PRIVATE SDL2::SDL2)
+    target_link_libraries(${TARGET} PRIVATE SDL2::SDL2)
     set_source_files_properties(playback.cpp PROPERTIES COMPILE_FLAGS -DSDL2_INSTALL=1)
 endif()
 
-target_link_libraries(cli PRIVATE ggml tts)
+target_link_libraries(${TARGET} PRIVATE ggml tts)


### PR DESCRIPTION
This disambiguation eases system-wide installation. The newly-prefixed name is more learnable and less collision-prone.