### PR TITLE
Fix Windows compilation and debug assertion failure

### DIFF
--- a/src/orpheus_model.cpp
+++ b/src/orpheus_model.cpp
@@ -1,8 +1,10 @@
 #include "orpheus_model.h"
 
+#include <array>
+
 // These tokens and variables aren't defined in the Orpheus' model configuration but instead are defined inline in various python functions.
 // As such, they are not discoverable so defining them as unconfigurable constants should be fine.
-static constexpr std::array<std::string, 7> orpheus_voices = {"zoe", "zac","jess", "leo", "mia", "julia", "leah"};
+static constexpr std::array<const char *, 7> orpheus_voices{"zoe", "zac","jess", "leo", "mia", "julia", "leah"};
 static constexpr std::array<uint32_t, 2> orpheus_prepended_tokens = { 128259, 128000 };
 static constexpr std::array<uint32_t, 4> orpheus_appended_tokens = { 128009, 128260, 128261, 128257 };
 

--- a/src/phonemizer.cpp
+++ b/src/phonemizer.cpp
@@ -409,7 +409,7 @@ void word_phonemizer::add_rule(std::vector<std::string> keys, std::string phonem
 	phonemizer_rule * current_rule = nullptr;
 	for (int i = 0; i < keys.size(); i++) {
 		if (current_rule) {
-			if (current_rule->rules.find(keys[i]) == rules.end()) {
+			if (!current_rule->rules.contains(keys[i])) {
 				phonemizer_rule * nrule = new phonemizer_rule;
 				current_rule->rules[keys[i]] = nrule;
 				current_rule = nrule;
@@ -1178,4 +1178,3 @@ struct phonemizer * phonemizer_from_file(const std::string fname, const std::str
     }
     return phonemizer_from_gguf(meta_ctx, espeak_voice_code);
 }
-

--- a/src/util.h
+++ b/src/util.h
@@ -1,8 +1,9 @@
 #ifndef util_h
 #define util_h
 
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include <functional>
-#include <math.h>
 #include <random>
 #include <stdio.h>
 #include <string>


### PR DESCRIPTION
Fixes: #109
Also gets this to build in VS Code on Windows with https://gist.github.com/robotdad/83041ccfe1bea895ffa0739192771732 by fixing the array initialization.
The phonemizer change fixed undefined behavior, but I'm not sure that bug had caused the crash in #104.

`settings.json` I used for testing:
```json
{
    "files.associations": {
        "array": "cpp"
    },
    "cmake.debugConfig": {
        "args": [
            "-nt",
            "4",
            "-p",
            "Hello",
            "-mp",
            "C:\\Users\\Home\\Downloads\\Kokoro_no_espeak.gguf"
        ]
    }
}
```